### PR TITLE
Add live traffic-aware motorcycle routing model

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.10+](https://img.shields.io/badge/Python-3.10%2B-green.svg)](https://python.org)
-[![Release](https://img.shields.io/badge/Release-v0.4.0-black.svg)](https://github.com/alipasha03/motomap/releases/tag/v0.4.0)
+[![Release](https://img.shields.io/badge/Release-v0.6.0-black.svg)](https://github.com/alipasha03/motomap/releases/tag/v0.6.0)
 [![Status](https://img.shields.io/badge/Status-In%20Development-orange.svg)]()
 
 *Most navigation apps optimize for cars.*
@@ -59,9 +59,25 @@
 
 ## Overview
 
-MOTOMAP is an open-source routing engine focused on motorcycle behavior rather than general-purpose car navigation. The project combines OSM road graphs, elevation and grade data, traffic-aware travel times, and rider preferences to produce routes that are faster, safer, or more enjoyable depending on the selected mode.
+MOTOMAP is an open-source routing engine focused on motorcycle behavior rather than general-purpose car navigation. The project combines OSM road graphs, elevation and grade data, live traffic-aware travel times, weather and incident safety signals, and rider preferences to produce routes that are faster, safer, or more enjoyable depending on the selected mode.
 
 The core routing algorithm lives in a single policy module ([`motomap/algorithm.py`](motomap/algorithm.py)) that the entire project depends on. All cost functions, filtering rules, and search logic are centralized there, preventing rule duplication across loaders, validators, and API code.
+
+---
+
+## New in v0.6.0
+
+- Live traffic-aware edge timing: `vc_ratio`, directional `traffic_volume_vph`, provider traffic categories, and observed `traffic_speed_kmh` now feed the speed model directly.
+- BPR plus live-speed blending: the car-speed estimate blends structural congestion modeling with live observations instead of relying on one flat multiplier.
+- Context-aware lane filtering: filtering is now treated as a bounded low-speed mixed-traffic maneuver and is suppressed or reduced by tunnels, night context, heavy vehicles, narrow lanes, and bad weather.
+- Weather and incident-aware route cost: `standart`, `viraj_keyfi`, and `guvenli` now react differently to `weather_overall_safety` and `incident_severity`.
+- Automatic traffic cache invalidation: live traffic and safety metadata now participate in graph cache state, so updated edge traffic forces travel-time recomputation automatically.
+
+See:
+
+- [`docs/releases.html`](docs/releases.html)
+- [`docs/release-notes/v0.6.0.md`](docs/release-notes/v0.6.0.md)
+- [`docs/research/2026-04-12-live-traffic-motorcycle-routing.md`](docs/research/2026-04-12-live-traffic-motorcycle-routing.md)
 
 ---
 
@@ -90,6 +106,9 @@ motomap/                          # Core Python package
   elevation.py                    # Elevation API with retry/fallback/degrade
   osm_validator.py                # Compatibility wrappers for edge filtering
   router.py                       # Compatibility exports for routing functions
+  weather/
+    assessment.py                 # Road safety and lane-splitting weather assessment
+    models.py                     # Weather data and road-condition dataclasses
 
 tests/                            # Test suite
   test_algorithm.py               # Core algorithm unit + randomized tests
@@ -205,11 +224,19 @@ derived from HCM (Highway Capacity Manual) Chapter 23 methodology, adapted for
 motorcycle dynamics:
 
 $$
-V_{eff}(e) = V_{posted}(e) \times f_{class}(e) \times f_{surface}(e) \times f_{grade}(e) \times f_{global}
+V_{ff}(e) = V_{posted}(e) \times f_{class}(e) \times f_{surface}(e) \times f_{grade}(e) \times f_{global}
 $$
 
 $$
-T_{road}(e) = \frac{L(e)}{V_{eff}(e) \;/\; 3.6} + \delta_{intersection}(e)
+V_{car}^{BPR}(e) = V_{ff}(e) \times \frac{1}{1 + \alpha_e \left(\frac{V}{C}\right)_e^{\beta_e}}
+$$
+
+$$
+V_{car}^{*}(e) = (1-\lambda_e)\,V_{car}^{BPR}(e) + \lambda_e\,V_{live}(e)
+$$
+
+$$
+T_{road}(e) = \frac{L(e)}{V_{moto}(e) \;/\; 3.6} + \delta_{intersection}(e)
 $$
 
 | Factor | Meaning | Source |
@@ -217,7 +244,9 @@ $$
 | $f_{class}$ | Road-class free-flow factor (HCM Table 23-1 adapted) | `FREE_FLOW_SPEED_FACTOR` in config |
 | $f_{surface}$ | Pavement quality reduction (motorcycle-specific) | `SURFACE_SPEED_FACTOR` in config |
 | $f_{grade}$ | Grade speed reduction: $\max(0.4,\; 1 - 0.35 \times \|grade\|)$ | HCM Exhibit 23-8 simplified |
-| $f_{global}$ | Runtime calibration knob (residual congestion proxy) | `MOTOMAP_SPEED_FACTOR` env (default 0.55) |
+| $f_{global}$ | Runtime calibration knob | `MOTOMAP_SPEED_FACTOR` env (default 0.55) |
+| $\left(\frac{V}{C}\right)_e$ | direct `vc_ratio` or directional volume/capacity estimate | live traffic metadata |
+| $\lambda_e$ | confidence weight for live speed blending | `traffic_confidence` / `speed_confidence` |
 | $\delta_{intersection}$ | Per-edge intersection delay by road class | `INTERSECTION_DELAY_S` in config |
 
 #### Road-Class Free-Flow Factors
@@ -270,38 +299,37 @@ $$
 > **Calibration loader:** `motomap/algorithm.py` &mdash; `runtime_calibration_from_env()`
 > reads and clamps override values from environment variables.
 >
-> **Design note:** Without real-time traffic volume data, the model cannot apply the
-> full BPR (Bureau of Public Roads) volume-delay function
-> $t = t_{ff} \times [1 + \alpha(V/C)^\beta]$.  The `speed_factor` serves as a
-> residual congestion proxy that can be tuned per deployment context or replaced
-> with a BPR layer when live traffic feeds become available.
+> **Current implementation:** the routing core now accepts live traffic through
+> `edge_data["vc_ratio"]`, directional `traffic_volume_vph`, provider traffic
+> categories such as `NORMAL` / `SLOW` / `TRAFFIC_JAM`, and observed
+> `traffic_speed_kmh`. When those are missing, the model falls back to
+> `PEAK_HOUR_VC_RATIO` planning defaults.
 
 ---
 
 ### 3. Lane-Filtering Speed Model
 
-Moto speed is estimated from the forward lane count and current traffic conditions:
+Lane filtering is now modeled as a bounded low-speed mixed-traffic maneuver rather than a permanent speed bonus:
 
 $$
-V_{moto} = \begin{cases}
-V_{car} + 5 & \text{if } n_{lane} = 1 \\
-\max(V_{car} + 15,\ 25) & \text{if } n_{lane} = 2 \\
-\max(V_{car} + 20,\ 35) & \text{if } n_{lane} \geq 3
-\end{cases}
+V_{moto}(e) =
+\min\!\left(
+V_{car}^{*}(e) + \Delta_{lane}(e)\,m_{weather}(e)\,m_{context}(e),
+V_{filter,max}
+\right)
 $$
 
 Where:
 
-- $V_{moto}$ is the estimated motorcycle speed in km/h
-- $V_{car}$ is the observed or simulated car speed in km/h
-- $n_{lane}$ is the number of forward lanes
+- $V_{car}^{*}(e)$ is the blended car-speed estimate after BPR and live traffic
+- $\Delta_{lane}(e)$ is the lane-count-based motorcycle advantage
+- $m_{weather}(e)$ comes from `lane_splitting_modifier` or weather safety fallback
+- $m_{context}(e)$ is reduced by tunnel context, night riding, narrow lane width, and heavy-vehicle share
 
-If traffic is already flowing close to the speed limit, the lane-filtering bonus is disabled and motorcycles follow the same effective speed as cars.
+Filtering only activates in congested low-speed conditions. When traffic is flowing freely, motorcycles fall back to the same effective movement speed as surrounding traffic.
 
-> **Note:** The lane-filtering speed model is described here as a design target.
-> The current implementation uses `maxspeed * speed_factor` as a practical approximation
-> until live traffic data is integrated.
-> See [`motomap/algorithm.py:511-537`](motomap/algorithm.py#L511) &mdash; `compute_edge_travel_time()`.
+> **Current implementation:** see `motomap/algorithm.py` &mdash;
+> `_resolve_lane_splitting_modifier()` and `_effective_speed_kmh()`.
 
 ---
 
@@ -828,7 +856,7 @@ High-level phase plan:
 2. **Core routing:** lane filtering, CC restrictions, grade penalties, cost engine, router
 3. **Touring mode:** surface preferences, sinuosity, scenic weighting
 4. **Evaluation and simulation:** benchmarks, map matching, metrics, visualization
-5. **Delivery:** API layer, live traffic integration, mobile MVP
+5. **Delivery:** API layer, production traffic-provider adapters, mobile MVP
 
 The detailed implementation plans live in [`docs/plans/`](docs/plans/).
 
@@ -836,9 +864,9 @@ The detailed implementation plans live in [`docs/plans/`](docs/plans/).
 
 ## Project Status
 
-- Completed: algorithm framing, documentation baseline, initial data pipeline, benchmark planning
-- In progress: routing calibration, OSM filtering, benchmark execution, backend hardening
-- Planned: production API, live traffic integration, mobile product surface
+- Completed: live traffic-aware routing core, weather-aware route costs, documentation baseline, initial data pipeline, GitHub and website release notes
+- In progress: provider-specific traffic adapters, routing calibration, benchmark execution, backend hardening
+- Planned: production API rollout, mobile product surface, trace-based calibration loops
 
 Open GitHub issues observed via `gh`:
 
@@ -854,9 +882,13 @@ Open GitHub issues observed via `gh`:
 | Motorcycle displacement | $CC$ | user profile | enables/disables highway access and grade penalties | [`algorithm.py:626`](motomap/algorithm.py#L626), [`algorithm.py:660`](motomap/algorithm.py#L660) |
 | Forward lane count | $n_{lane}$ | OSM `lanes` + `oneway` | increases lane-filtering speed advantage | [`algorithm.py:392`](motomap/algorithm.py#L392) |
 | Road grade | $\alpha$ | DEM / elevation APIs | raises edge cost on steep climbs | [`elevation.py:89`](motomap/elevation.py#L89) |
-| Surface | `surface` | OSM | affects touring preferences | [`config.py:51`](motomap/config.py#L51) |
+| Surface | `surface` | OSM | affects free-flow speed and touring preferences | [`config.py:51`](motomap/config.py#L51) |
 | Riding mode | `mode` | user input | switches objective between time and enjoyment | [`algorithm.py:674`](motomap/algorithm.py#L674) |
-| Car speed | $V_{car}$ | live traffic or simulation | drives lane-filtering ETA model | [`algorithm.py:511`](motomap/algorithm.py#L511) |
+| V/C ratio | $\left(\frac{V}{C}\right)$ | direct feed or live volume/capacity | drives BPR congestion response | `algorithm.py` |
+| Live speed | $V_{live}$ | traffic provider feed | blended into edge speed estimate | `algorithm.py` |
+| Live speed confidence | $\lambda$ | traffic provider feed | controls trust in observed speed | `algorithm.py` |
+| Weather safety | $S_e$ | weather assessment | slows edges and penalizes route cost | `algorithm.py`, `weather/assessment.py` |
+| Incident severity | $I_e$ | traffic/incident feed | increases mode-specific edge cost | `algorithm.py` |
 | Speed limit | $V_{max}$ | OSM `maxspeed` | caps optimistic motorcycle speed | [`config.py:18`](motomap/config.py#L18) |
 | Toll flag | `toll` | OSM | toll-free route filtering | [`algorithm.py:448`](motomap/algorithm.py#L448) |
 | Ferry flag | `route`/`ferry` | OSM | ferry edge detection and timing | [`algorithm.py:460`](motomap/algorithm.py#L460) |
@@ -865,7 +897,14 @@ Open GitHub issues observed via `gh`:
 
 ## Version Notes
 
-The repository currently has a Git tag at `v0.4.0`. Some application manifests still report `1.0.0` as a local package/API version, so release versioning is not yet fully normalized across the repo.
+- Current draft release branch: `feature/live-traffic-routing-v0.6.0`
+- Current release tag: `v0.6.0`
+- Main additions in `v0.6.0`: live traffic-aware routing, directional `V/C` from flow, live-speed blending, weather and incident-aware edge costs, context-aware lane filtering, and updated GitHub / website release notes
+
+For the full release history and formula notes, see:
+
+- [`docs/releases.html`](docs/releases.html)
+- [`docs/release-notes/v0.6.0.md`](docs/release-notes/v0.6.0.md)
 
 ---
 

--- a/README.tr.md
+++ b/README.tr.md
@@ -7,33 +7,52 @@
 
 # MOTOMAP
 
-### Motosikletçiler Için Akilli Rota Optimizasyon Motoru
+### MotosikletÃ§iler IÃ§in Akilli Rota Optimizasyon Motoru
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.10+](https://img.shields.io/badge/Python-3.10%2B-green.svg)](https://python.org)
+[![Release](https://img.shields.io/badge/Release-v0.6.0-black.svg)](https://github.com/alipasha03/motomap/releases/tag/v0.6.0)
 [![Status](https://img.shields.io/badge/Status-Gelistiriliyor-orange.svg)]()
 
-*Standart navigasyon uygulamalari arabalara göre rota çizerken,*
+*Standart navigasyon uygulamalari arabalara gÃ¶re rota Ã§izerken,*
 *MOTOMAP motosikletlerin fiziksel avantajlarini ve kisitlamalarini matematiksel olarak modelleyerek*
-*bireysellestirilmis rotalar üretir.*
+*bireysellestirilmis rotalar Ã¼retir.*
 
 </div>
 
 ---
 
-## Içindekiler
+## v0.6.0 Guncellemesi
+
+Bu surumde README, algoritma ve release note'lar yeni canli trafik modeline gore guncellendi.
+
+- Canli trafik destekli rota maliyeti: `vc_ratio`, `traffic_volume_vph`, trafik hiz kategorileri ve `traffic_speed_kmh` artik dogrudan hiz modeline giriyor.
+- BPR + live speed blending: yapisal sikisiklik modeli ile canli gozlem birlestiriliyor.
+- Baglama duyarli lane filtering: tunnel, gece, agir tasit payi, dar serit ve hava kosullari filtreleme avantajini azaltabiliyor veya kapatabiliyor.
+- Weather ve incident-aware route cost: `weather_overall_safety` ve `incident_severity` artik rota agirligina giriyor.
+- Otomatik cache invalidation: edge trafik verisi degisince travel time tekrar hesaplaniyor.
+
+Detaylar:
+
+- [`docs/releases.html`](docs/releases.html)
+- [`docs/release-notes/v0.6.0.md`](docs/release-notes/v0.6.0.md)
+- [`docs/research/2026-04-12-live-traffic-motorcycle-routing.md`](docs/research/2026-04-12-live-traffic-motorcycle-routing.md)
+
+---
+
+## IÃ§indekiler
 
 - [Neden MOTOMAP?](#neden-motomap)
-- [Temel Özellikler](#temel-özellikler)
+- [Temel Ã–zellikler](#temel-Ã¶zellikler)
 - [Teknik Mimari](#teknik-mimari)
 - [Veri Kaynaklari](#veri-kaynaklari)
 - [Teknoloji Yigini](#teknoloji-yigini)
 - [Kurulum](#kurulum)
-- [Hizli Baslangiç](#hizli-baslangiç)
-- [DEM/API Çiktilari](#demapi-çiktilari)
+- [Hizli BaslangiÃ§](#hizli-baslangiÃ§)
+- [DEM/API Ã‡iktilari](#demapi-Ã§iktilari)
 - [Uygulama Plani (Implementation Plan)](#uygulama-plani-implementation-plan)
 - [Proje Durumu](#proje-durumu)
-- [Algoritma Parametreleri Özet Tablosu](#algoritma-parametreleri-özet-tablosu)
+- [Algoritma Parametreleri Ã–zet Tablosu](#algoritma-parametreleri-Ã¶zet-tablosu)
 - [Lisans](#lisans)
 - [Yazar](#yazar)
 
@@ -41,48 +60,73 @@
 
 ## Neden MOTOMAP?
 
-Mevcut navigasyon uygulamalari (Google Maps, Yandex, Apple Maps) tüm araçlara ayni rotayi sunar. Ancak motosikletler trafikte temelden farkli hareket eder:
+Mevcut navigasyon uygulamalari (Google Maps, Yandex, Apple Maps) tÃ¼m araÃ§lara ayni rotayi sunar. Ancak motosikletler trafikte temelden farkli hareket eder:
 
-> Sikisik bir E-5 trafiginde arabalar **duragan** haldeyken, motosikletler serit aralarindan siyrilarak ilerleyebilir. Google Maps "45 dakika" gösterirken, bir motosikletçi ayni mesafeyi **15 dakikada** katedebilir.
+> Sikisik bir E-5 trafiginde arabalar **duragan** haldeyken, motosikletler serit aralarindan siyrilarak ilerleyebilir. Google Maps "45 dakika" gÃ¶sterirken, bir motosikletÃ§i ayni mesafeyi **15 dakikada** katedebilir.
 
-MOTOMAP bu farki algoritmik olarak modelleyen **ilk açik kaynak navigasyon motorudur.**
+MOTOMAP bu farki algoritmik olarak modelleyen **ilk aÃ§ik kaynak navigasyon motorudur.**
 
 ---
 
-## Temel Özellikler
+## Temel Ã–zellikler
 
 ### 1. Serit Filtreleme (Lane Filtering)
 
-Sikisik trafikte motosikletlerin serit aralarindan geçebilme avantajini modelleyen dinamik hiz hesaplamasi. Motosiklet hizi, gidis yönündeki serit sayisina ve anlik trafik durumuna bagli olarak hesaplanir:
+Lane filtering artik sabit bir hiz bonusu degil, dusuk hizli mixed-traffic manevrasi olarak modelleniyor. Temel fikir:
 
 $$
-V_{moto} = \begin{cases}
-V_{araba} + 5 & \text{if } n_{serit} = 1 \\
-\max(V_{araba} + 15,\ 25) & \text{if } n_{serit} = 2 \\
-\max(V_{araba} + 20,\ 35) & \text{if } n_{serit} \geq 3
-\end{cases}
+V_{moto}(e) =
+\min\!\left(
+V_{araba}^{*}(e) + \Delta_{serit}(e)\,m_{hava}(e)\,m_{baglam}(e),
+V_{filter,max}
+\right)
 $$
 
 Burada:
-- $V_{moto}$ : Motosikletin tahmini hizi (km/s)
-- $V_{araba}$ : Arabalarin anlik ortalama hizi (km/s)
-- $n_{serit}$ : Gidis yönündeki serit sayisi
+- $V_{araba}^{*}$ : BPR + canli trafik ile bulunan araba hizi
+- $\Delta_{serit}$ : gidis yonundeki serit sayisina bagli avantaj
+- $m_{hava}$ : weather lane-splitting modifier
+- $m_{baglam}$ : tunnel, gece, dar serit ve agir tasit gibi baglamsal azalticilar
 
-| Senaryo | Serit (Gidis) | Araba Hizi | Motor Hizi | Açiklama |
-|:---:|:---:|:---:|:---:|:---|
-| Tek seritli yol | 1 | 10 km/s | 10 km/s | Manevra alani dar, sinirli avantaj |
-| Çift seritli cadde | 2 | 10 km/s | 25 km/s | Serit arasi filtreleme mümkün |
-| Genis bulvar / otoyol | 3+ | 5 km/s | 35 km/s | Çoklu kaçis yolu, rahat geçis |
+Filtreleme sadece sikisik ve dusuk hizli trafikte acilir. Trafik akiciysa motor, cevredeki trafik akisina geri doner.
 
-> **Not:** Trafik akici ise ($V_{araba} \geq V_{max} - 10$), filtrelemeye gerek yoktur ve motor arabalarla ayni hizda gider.
+Ek olarak:
+
+- `tunnel=yes` olan kenarlarda filtering bastirilir
+- gece kosullarinda avantaj azaltilir
+- agir tasit orani yuksekse avantaj azaltilir
+- lane width dar ise avantaj azaltilir
 
 ---
 
-### 2. Motor Hacmine Göre Bireysel Rota (CC Bazli Optimizasyon)
+### 1.1 Canli Trafik ve Hava Katmani
+
+Yeni surumde edge travel time su tip girdilerden beslenebilir:
+
+- `vc_ratio`
+- `traffic_volume_vph`
+- `traffic_speed_kmh`
+- `traffic_confidence`
+- `weather_overall_safety`
+- `incident_severity`
+
+Bu sayede sistem sadece OSM hiz limitine degil, edge bazli canli trafik ve guvenlik sinyallerine de bakar.
+
+$$
+V_{araba}^{*}(e) = (1-\lambda_e)\,V_{BPR}(e) + \lambda_e\,V_{live}(e)
+$$
+
+$$
+C_{mod,e} = T_e \cdot \left[1 + \omega_{mod}(1-S_e) + \phi_{mod}I_e\right]
+$$
+
+---
+
+### 2. Motor Hacmine GÃ¶re Bireysel Rota (CC Bazli Optimizasyon)
 
 #### Otoban Kisitlamasi
 
-50cc ve alti motosikletler yasal olarak otobana çikamazlar. Bu kisitlama sonsuz maliyet ile modellenir:
+50cc ve alti motosikletler yasal olarak otobana Ã§ikamazlar. Bu kisitlama sonsuz maliyet ile modellenir:
 
 $$
 C_{otoban}(e) = \begin{cases}
@@ -93,7 +137,7 @@ $$
 
 #### Egim Cezasi
 
-Düsük hacimli motorlar dik yokuslarda zorlanir. Egim cezasi çarpani:
+DÃ¼sÃ¼k hacimli motorlar dik yokuslarda zorlanir. Egim cezasi Ã§arpani:
 
 $$
 C_{egim}(\alpha, CC) = \begin{cases}
@@ -104,7 +148,7 @@ C_{egim}(\alpha, CC) = \begin{cases}
 \end{cases}
 $$
 
-Burada $\alpha$ yolun egim yüzdesidir ve DEM (Digital Elevation Model) verisinden hesaplanir.
+Burada $\alpha$ yolun egim yÃ¼zdesidir ve DEM (Digital Elevation Model) verisinden hesaplanir.
 
 | CC Sinifi | Otoban Erisimi | %5-8 Egim | %8-12 Egim | %12+ Egim |
 |:---:|:---:|:---:|:---:|:---:|
@@ -114,23 +158,23 @@ Burada $\alpha$ yolun egim yüzdesidir ve DEM (Digital Elevation Model) verisinde
 
 ---
 
-### 3. Çift Modlu Sürücü Deneyimi
+### 3. Ã‡ift Modlu SÃ¼rÃ¼cÃ¼ Deneyimi
 
 ```mermaid
 flowchart TD
     A["Kullanici Uygulamaya Girer"]
-    B{"Sürüs Amaci?"}
-    C["IS IÇIN"]
-    D["GEZI IÇIN"]
+    B{"SÃ¼rÃ¼s Amaci?"}
+    C["IS IÃ‡IN"]
+    D["GEZI IÃ‡IN"]
 
-    C1["Baslangiç & Bitis Noktasi"]
-    C2{"Ücretli Yol Tercihi?"}
-    C3["ucretli_serbest: Ücretli + Ücretsiz Adaylar"]
-    C4["ucretsiz: Ücretli Kenarlar Dislanir"]
-    C5["Maliyet Minimizasyonu & Rota Seçimi"]
+    C1["BaslangiÃ§ & Bitis Noktasi"]
+    C2{"Ãœcretli Yol Tercihi?"}
+    C3["ucretli_serbest: Ãœcretli + Ãœcretsiz Adaylar"]
+    C4["ucretsiz: Ãœcretli Kenarlar Dislanir"]
+    C5["Maliyet Minimizasyonu & Rota SeÃ§imi"]
     C6["Lane Filtering Aktif"]
 
-    D1["Yüzey Tercihi"]
+    D1["YÃ¼zey Tercihi"]
     D2["Viraj Seviyesi"]
     D3["Manzara Tercihi"]
     D4["Keyif Rotasi"]
@@ -152,7 +196,7 @@ flowchart TD
     style D4 fill:#15803d,color:#fff
 ```
 
-#### Mod 1 — Is Için: Zaman Minimizasyonu
+#### Mod 1 â€” Is IÃ§in: Zaman Minimizasyonu
 
 Hedef fonksiyon:
 
@@ -160,48 +204,48 @@ $$
 \min_{P \in \mathcal{P}} \sum_{e \in P} T_{moto}(e)
 $$
 
-$\mathcal{P}$: Tüm mümkün rotalar kümesi, $T_{moto}(e)$: Kenar $e$ üzerinde motosiklet geçis süresi.
+$\mathcal{P}$: TÃ¼m mÃ¼mkÃ¼n rotalar kÃ¼mesi, $T_{moto}(e)$: Kenar $e$ Ã¼zerinde motosiklet geÃ§is sÃ¼resi.
 
-Ücretli/ücretsiz tercih için iki aday rota birlikte degerlendirilir:
+Ãœcretli/Ã¼cretsiz tercih iÃ§in iki aday rota birlikte degerlendirilir:
 
 $$
 P_{serbest}=\arg\min_{P}\sum_{e\in P}C_0(e),\qquad
 P_{ucretsiz}=\arg\min_{P:U(e)=0\ \forall e\in P}\sum_{e\in P}C_0(e)
 $$
 
-- `ucretli_serbest`: ücretli + ücretsiz adaylar birlikte optimize edilir.
-- `ucretsiz`: ücretli kenarlar hard constraint ile dislanir.
+- `ucretli_serbest`: Ã¼cretli + Ã¼cretsiz adaylar birlikte optimize edilir.
+- `ucretsiz`: Ã¼cretli kenarlar hard constraint ile dislanir.
 
-#### Mod 2 — Gezi Için: Keyif Maksimizasyonu
+#### Mod 2 â€” Gezi IÃ§in: Keyif Maksimizasyonu
 
-Gezi modunda her kenara ceza/ödül çarpanlari uygulanir:
+Gezi modunda her kenara ceza/Ã¶dÃ¼l Ã§arpanlari uygulanir:
 
-**Yüzey Tipi Çarpani:**
+**YÃ¼zey Tipi Ã‡arpani:**
 
 $$
-C_{yüzey}(e) = \begin{cases}
+C_{yÃ¼zey}(e) = \begin{cases}
 0.5 & \text{if } surface(e) = \text{tercih edilen} \\
-1.0 & \text{if } surface(e) = \text{nötr} \\
+1.0 & \text{if } surface(e) = \text{nÃ¶tr} \\
 50.0 & \text{if } surface(e) = \text{istenmeyen}
 \end{cases}
 $$
 
 **Viraj Skoru (Sinuosity Index):**
 
-Bir yol segmentinin ne kadar virajli oldugu su oranla ölçülür:
+Bir yol segmentinin ne kadar virajli oldugu su oranla Ã¶lÃ§Ã¼lÃ¼r:
 
 $$
-S(e) = \frac{L_{gerçek}(e)}{L_{kus\ uçusu}(e)}
+S(e) = \frac{L_{gerÃ§ek}(e)}{L_{kus\ uÃ§usu}(e)}
 $$
 
-- $S = 1.0$ ise yol düz, $S > 1.2$ ise virajli.
+- $S = 1.0$ ise yol dÃ¼z, $S > 1.2$ ise virajli.
 
-**Viraj Ödül Çarpani:**
+**Viraj Ã–dÃ¼l Ã‡arpani:**
 
 $$
 C_{viraj}(e) = \begin{cases}
-0.3 & \text{if } S(e) > 1.2 \text{ (virajli yol ödüllendirilir)} \\
-1.5 & \text{if } S(e) \approx 1.0 \text{ (düz yol cezalandirilir)}
+0.3 & \text{if } S(e) > 1.2 \text{ (virajli yol Ã¶dÃ¼llendirilir)} \\
+1.5 & \text{if } S(e) \approx 1.0 \text{ (dÃ¼z yol cezalandirilir)}
 \end{cases}
 $$
 
@@ -215,19 +259,19 @@ $$
 graph LR
     subgraph "Veri Katmani"
         OSM["OpenStreetMap<br/>Yol Agi"]
-        DEM["NASA SRTM DEM<br/>Yükseklik Verisi"]
+        DEM["NASA SRTM DEM<br/>YÃ¼kseklik Verisi"]
         IBB["IBB API<br/>Canli Trafik"]
     end
 
     subgraph "Islem Katmani"
         GRAF["Graf Olusturucu<br/>(osmnx + networkx)"]
-        SIM["Trafik Simülatörü<br/>(numpy + random)"]
+        SIM["Trafik SimÃ¼latÃ¶rÃ¼<br/>(numpy + random)"]
         COST["Maliyet Hesaplayici<br/>(Lane Filter + CC + Egim)"]
-        DIJKSTRA["Rota Çözücü<br/>(Dijkstra / A*)"]
+        DIJKSTRA["Rota Ã‡Ã¶zÃ¼cÃ¼<br/>(Dijkstra / A*)"]
     end
 
     subgraph "Sunum Katmani"
-        FOLIUM["Folium Harita<br/>(HTML Çiktisi)"]
+        FOLIUM["Folium Harita<br/>(HTML Ã‡iktisi)"]
         API["REST API<br/>(Flask / FastAPI)"]
         MOBILE["Mobil Uygulama<br/>(Flutter)"]
     end
@@ -256,16 +300,16 @@ $$
 W(e) = T_{moto}(e) \times C_{otoban}(e) \times C_{egim}(e) \times C_{mod}(e)
 $$
 
-| Bilesen | Formül | Açiklama |
+| Bilesen | FormÃ¼l | AÃ§iklama |
 |:---|:---:|:---|
 | $T_{moto}(e)$ | $\dfrac{d(e)}{V_{moto}(e) / 3.6}$ | Kenar uzunlugu / motosiklet hizi (saniye) |
 | $C_{otoban}(e)$ | $1.0$ veya $\infty$ | CC bazli yasal otoban kisitlamasi |
-| $C_{egim}(e)$ | $1.0 - 10.0$ | Yokus yukari egim ceza çarpani |
-| $C_{mod}(e)$ | $0.3 - 50.0$ | Gezi modunda yüzey + viraj çarpani |
+| $C_{egim}(e)$ | $1.0 - 10.0$ | Yokus yukari egim ceza Ã§arpani |
+| $C_{mod}(e)$ | $0.3 - 50.0$ | Gezi modunda yÃ¼zey + viraj Ã§arpani |
 
-### Gidis Yönündeki Serit Sayisi
+### Gidis YÃ¶nÃ¼ndeki Serit Sayisi
 
-OSM verisi genellikle toplam serit sayisini verir. Gidis yönündeki serit:
+OSM verisi genellikle toplam serit sayisini verir. Gidis yÃ¶nÃ¼ndeki serit:
 
 $$
 n_{serit}^{gidis} = \begin{cases}
@@ -286,9 +330,9 @@ sequenceDiagram
     participant API as Trafik API
 
     U->>APP: Kayit (CC bilgisi)
-    U->>APP: A noktasi, B noktasi, Mod seçimi
+    U->>APP: A noktasi, B noktasi, Mod seÃ§imi
     APP->>GRAF: Rota talebi
-    GRAF->>OSM: Bölge yol agi çek
+    GRAF->>OSM: BÃ¶lge yol agi Ã§ek
     OSM-->>GRAF: MultiDiGraph
     GRAF->>DEM: Rakim verisi oku (.tif)
     DEM-->>GRAF: Node elevations
@@ -297,7 +341,7 @@ sequenceDiagram
     API-->>GRAF: Araba hizlari
     GRAF->>GRAF: Lane filtering hiz hesabi
     GRAF->>GRAF: Maliyet fonksiyonu hesapla
-    GRAF->>GRAF: Dijkstra çalistir
+    GRAF->>GRAF: Dijkstra Ã§alistir
     GRAF-->>APP: Optimal rota + ETA
     APP-->>U: Harita + Uyarilar
 ```
@@ -309,19 +353,19 @@ sequenceDiagram
 | Veri | Kaynak | Format | Kullanim |
 |:---|:---|:---:|:---|
 | Yol agi (sokak grafi) | OpenStreetMap | `MultiDiGraph` | Topoloji, yol sinifi, serit, hiz limiti |
-| Yükseklik / egim | NASA SRTM DEM | `.tif` (GeoTIFF) | Rakim farkindan egim hesabi |
-| Anlik trafik | IBB API / Simülasyon | JSON | Araba hizlari (ileride gerçek veri) |
-| Yüzey, köprü, tünel | OSM etiketleri | Edge attributes | Gezi modu tercihleri, uyarilar |
+| YÃ¼kseklik / egim | NASA SRTM DEM | `.tif` (GeoTIFF) | Rakim farkindan egim hesabi |
+| Anlik trafik | IBB API / SimÃ¼lasyon | JSON | Araba hizlari (ileride gerÃ§ek veri) |
+| YÃ¼zey, kÃ¶prÃ¼, tÃ¼nel | OSM etiketleri | Edge attributes | Gezi modu tercihleri, uyarilar |
 
 ### Kullanilan OSM Etiketleri
 
-| Etiket | Örnek Deger | Algoritmadaki Rolü |
+| Etiket | Ã–rnek Deger | Algoritmadaki RolÃ¼ |
 |:---|:---|:---|
 | `highway` | `motorway`, `primary`, `residential` | Yol sinifi ? otoban kisitlamasi, varsayilan hizlar |
 | `lanes` | `2`, `4`, `6` | Lane filtering hiz hesabi |
-| `oneway` | `yes`, `no` | Gidis yönündeki serit sayisini bulma |
+| `oneway` | `yes`, `no` | Gidis yÃ¶nÃ¼ndeki serit sayisini bulma |
 | `maxspeed` | `50`, `120` | Akici trafikte referans hiz |
-| `surface` | `asphalt`, `gravel`, `dirt` | Gezi modu yüzey filtresi |
+| `surface` | `asphalt`, `gravel`, `dirt` | Gezi modu yÃ¼zey filtresi |
 | `bridge` / `tunnel` | `yes` | GPS kaybi, buzlanma uyarilari |
 | `incline` | `10%`, `up` | Egim dogrulamasi |
 
@@ -335,14 +379,14 @@ graph TD
         A[osmnx] --> B[networkx]
         C[rasterio] --> A
         B --> D[Dijkstra / A*]
-        E[numpy] --> F[Trafik Simülasyonu]
+        E[numpy] --> F[Trafik SimÃ¼lasyonu]
         G[pandas / geopandas] --> A
         D --> H[folium]
     end
 
-    subgraph "Mobil Frontend — Planlanan"
+    subgraph "Mobil Frontend â€” Planlanan"
         I[Flutter / React Native]
-        J[REST API — FastAPI]
+        J[REST API â€” FastAPI]
     end
 
     D --> J --> I
@@ -354,15 +398,15 @@ graph TD
     style I fill:#f59e0b,color:#000
 ```
 
-| Kütüphane | Versiyon | Amaç |
+| KÃ¼tÃ¼phane | Versiyon | AmaÃ§ |
 |:---|:---:|:---|
 | `osmnx` | 1.9+ | OSM'den yol agi indirme, DEM'den rakim ekleme |
 | `networkx` | 3.0+ | Graf islemleri, Dijkstra / A* algoritmalari |
 | `pandas` | 2.0+ | Veri temizligi, eksik deger doldurma |
-| `geopandas` | 0.14+ | Mekânsal veri islemleri |
-| `numpy` | 1.24+ | Istatistiksel simülasyon veri üretimi |
+| `geopandas` | 0.14+ | MekÃ¢nsal veri islemleri |
+| `numpy` | 1.24+ | Istatistiksel simÃ¼lasyon veri Ã¼retimi |
 | `rasterio` | 1.3+ | DEM GeoTIFF dosyasi okuma |
-| `folium` | 0.15+ | Etkilesimli Leaflet harita çiktisi |
+| `folium` | 0.15+ | Etkilesimli Leaflet harita Ã§iktisi |
 
 ---
 
@@ -379,37 +423,37 @@ pip install osmnx networkx pandas geopandas numpy folium rasterio
 
 ### DEM Verisi Indirme
 
-Istanbul bölgesi için 30m çözünürlüklü SRTM verisini asagidaki kaynaklardan `.tif` formatinda indirin:
+Istanbul bÃ¶lgesi iÃ§in 30m Ã§Ã¶zÃ¼nÃ¼rlÃ¼klÃ¼ SRTM verisini asagidaki kaynaklardan `.tif` formatinda indirin:
 
 - [USGS EarthExplorer](https://earthexplorer.usgs.gov/)
 - [Copernicus DEM](https://spacedata.copernicus.eu/)
 - [CGIAR-CSI SRTM](https://srtm.csi.cgiar.org/)
 
-Indirilen dosyayi proje kök dizinine `istanbul_dem.tif` olarak kaydedin.
+Indirilen dosyayi proje kÃ¶k dizinine `istanbul_dem.tif` olarak kaydedin.
 
 ---
 
-## Hizli Baslangiç
+## Hizli BaslangiÃ§
 
 ```python
 from motomap import motomap_graf_olustur, maliyetleri_hesapla_ve_grafa_ekle, rota_ciz
 
-# 1. Graf olustur (pilot bölge: Kadiköy)
-G = motomap_graf_olustur("Kadiköy, Istanbul, Turkey", "istanbul_dem.tif")
+# 1. Graf olustur (pilot bÃ¶lge: KadikÃ¶y)
+G = motomap_graf_olustur("KadikÃ¶y, Istanbul, Turkey", "istanbul_dem.tif")
 
 # 2. Maliyetleri hesapla (50cc motor, is modu)
 G = maliyetleri_hesapla_ve_grafa_ekle(G, motor_cc=50, surus_amaci="is_icin")
 
-# 3. Rota bul ve görsellestir
+# 3. Rota bul ve gÃ¶rsellestir
 rota_ciz(G, baslangic_node, bitis_node)
-# Çikti: motomap_test_rotasi.html
+# Ã‡ikti: motomap_test_rotasi.html
 ```
 
 ---
 
-## DEM/API Çiktilari
+## DEM/API Ã‡iktilari
 
-Asagidaki artefaktlar OSM + Elevation API çagrilari ile üretilmistir:
+Asagidaki artefaktlar OSM + Elevation API Ã§agrilari ile Ã¼retilmistir:
 
 - `outputs/dem_api/moda_kadikoy_dem_api_map.npz`
 - `outputs/dem_api/moda_kadikoy_dem_api_map.pdf`
@@ -421,11 +465,11 @@ Asagidaki artefaktlar OSM + Elevation API çagrilari ile üretilmistir:
 
 ![DEM API Science Map](outputs/dem_api/moda_kadikoy_dem_api_map.svg)
 
-### Yükselti 3D Plot (Python)
+### YÃ¼kselti 3D Plot (Python)
 
 ![Elevation 3D Plot](outputs/dem_api/moda_kadikoy_elevation_3d.png)
 
-Üretim komutlari:
+Ãœretim komutlari:
 
 ```bash
 python -m scripts.dem_api_map_export --place "Moda, Kadikoy, Istanbul, Turkey" --output-dir outputs/dem_api --basename moda_kadikoy_dem_api_map
@@ -444,81 +488,81 @@ gantt
     dateFormat  YYYY-MM-DD
     axisFormat  %d %b
 
-    section Faz 1 — Altyapi
+    section Faz 1 â€” Altyapi
     Proje iskeleti ve bagimliliklar         :f1a, 2026-03-01, 3d
-    OSM veri çekme modülü                   :f1b, after f1a, 5d
+    OSM veri Ã§ekme modÃ¼lÃ¼                   :f1b, after f1a, 5d
     DEM entegrasyonu ve egim hesaplama      :f1c, after f1a, 5d
     Veri temizleme fonksiyonlari             :f1d, after f1b, 3d
 
-    section Faz 2 — Çekirdek Algoritma
+    section Faz 2 â€” Ã‡ekirdek Algoritma
     Lane filtering hiz fonksiyonu           :f2a, after f1d, 4d
     CC bazli kisitlama sistemi              :f2b, after f1d, 3d
-    Egim ceza çarpani                       :f2c, after f1c, 3d
+    Egim ceza Ã§arpani                       :f2c, after f1c, 3d
     Maliyet fonksiyonu birlestirme          :f2d, after f2a, 4d
-    Dijkstra rota çözücü                    :f2e, after f2d, 3d
+    Dijkstra rota Ã§Ã¶zÃ¼cÃ¼                    :f2e, after f2d, 3d
 
-    section Faz 3 — Gezi Modu
-    Yüzey tipi filtresi                     :f3a, after f2e, 3d
+    section Faz 3 â€” Gezi Modu
+    YÃ¼zey tipi filtresi                     :f3a, after f2e, 3d
     Sinuosity indeksi hesaplama             :f3b, after f2e, 4d
     Keyif maliyet fonksiyonu                :f3c, after f3a, 3d
 
-    section Faz 4 — Simülasyon ve Test
-    Akilli trafik simülatörü               :f4a, after f2e, 5d
-    Folium görsellestirme                   :f4b, after f2e, 4d
-    Uçtan uca test senaryolari              :f4c, after f4a, 5d
+    section Faz 4 â€” SimÃ¼lasyon ve Test
+    Akilli trafik simÃ¼latÃ¶rÃ¼               :f4a, after f2e, 5d
+    Folium gÃ¶rsellestirme                   :f4b, after f2e, 4d
+    UÃ§tan uca test senaryolari              :f4c, after f4a, 5d
 
-    section Faz 5 — Üretime Hazirlik
+    section Faz 5 â€” Ãœretime Hazirlik
     REST API sunucusu                       :f5a, after f4c, 7d
     IBB API entegrasyonu                    :f5b, after f5a, 7d
     Mobil uygulama MVP                      :f5c, after f5a, 21d
 ```
 
-### Detayli Faz Açiklamalari
+### Detayli Faz AÃ§iklamalari
 
-#### Faz 1 — Veri Altyapisi
+#### Faz 1 â€” Veri Altyapisi
 
-| Görev | Girdi | Çikti | Sorumlu |
+| GÃ¶rev | Girdi | Ã‡ikti | Sorumlu |
 |:---|:---|:---|:---:|
-| Proje iskeleti olustur | — | `motomap/` paket yapisi, `requirements.txt` | — |
-| `data_loader.py` : OSM veri çekme | Bölge adi (str) | `NetworkX MultiDiGraph` | — |
-| `elevation.py` : DEM entegrasyonu | `.tif` dosya yolu | Graf + `elevation`, `grade`, `grade_abs` | — |
-| `data_cleaner.py` : Eksik veri doldurma | Ham graf | Temiz graf (lanes, maxspeed, surface) | — |
+| Proje iskeleti olustur | â€” | `motomap/` paket yapisi, `requirements.txt` | â€” |
+| `data_loader.py` : OSM veri Ã§ekme | BÃ¶lge adi (str) | `NetworkX MultiDiGraph` | â€” |
+| `elevation.py` : DEM entegrasyonu | `.tif` dosya yolu | Graf + `elevation`, `grade`, `grade_abs` | â€” |
+| `data_cleaner.py` : Eksik veri doldurma | Ham graf | Temiz graf (lanes, maxspeed, surface) | â€” |
 
-#### Faz 2 — Çekirdek Algoritma
+#### Faz 2 â€” Ã‡ekirdek Algoritma
 
-| Görev | Girdi | Çikti | Formül |
+| GÃ¶rev | Girdi | Ã‡ikti | FormÃ¼l |
 |:---|:---|:---|:---:|
 | `lane_filter.py` : Hiz hesabi | $V_{araba}$, $n_{serit}$, $V_{max}$ | $V_{moto}$ | Serit bazli fonksiyon |
 | `cc_constraint.py` : Otoban engeli | CC, yol tipi | $C_{otoban}$ | $\infty$ veya $1.0$ |
-| `grade_penalty.py` : Egim cezasi | $\alpha$, CC | $C_{egim}$ | Derecelendirilmis çarpan |
-| `cost_engine.py` : Bilesik maliyet | Tüm çarpanlar | $W(e)$ | $T \times C_o \times C_e \times C_m$ |
-| `router.py` : Rota çözücü | Graf, A, B, weight | Node listesi + ETA | Dijkstra |
+| `grade_penalty.py` : Egim cezasi | $\alpha$, CC | $C_{egim}$ | Derecelendirilmis Ã§arpan |
+| `cost_engine.py` : Bilesik maliyet | TÃ¼m Ã§arpanlar | $W(e)$ | $T \times C_o \times C_e \times C_m$ |
+| `router.py` : Rota Ã§Ã¶zÃ¼cÃ¼ | Graf, A, B, weight | Node listesi + ETA | Dijkstra |
 
-#### Faz 3 — Gezi Modu
+#### Faz 3 â€” Gezi Modu
 
-| Görev | Girdi | Çikti | Formül |
+| GÃ¶rev | Girdi | Ã‡ikti | FormÃ¼l |
 |:---|:---|:---|:---:|
-| `surface_filter.py` | Tercih, `surface` tag | $C_{yüzey}$ | Ceza / nötr / ödül |
-| `sinuosity.py` | Edge geometri | $S(e)$ | $L_{gerçek} / L_{kus\ uçusu}$ |
-| `joy_cost.py` | Tüm tercih çarpanlari | `keyif_maliyeti` | $d \times C_y \times C_v$ |
+| `surface_filter.py` | Tercih, `surface` tag | $C_{yÃ¼zey}$ | Ceza / nÃ¶tr / Ã¶dÃ¼l |
+| `sinuosity.py` | Edge geometri | $S(e)$ | $L_{gerÃ§ek} / L_{kus\ uÃ§usu}$ |
+| `joy_cost.py` | TÃ¼m tercih Ã§arpanlari | `keyif_maliyeti` | $d \times C_y \times C_v$ |
 
-#### Faz 4 — Simülasyon ve Test
+#### Faz 4 â€” SimÃ¼lasyon ve Test
 
-| Görev | Girdi | Çikti |
+| GÃ¶rev | Girdi | Ã‡ikti |
 |:---|:---|:---|
-| `traffic_sim.py` : Trafik üreteci | Yol tipi, saat dilimi | Simüle araba hizlari |
+| `traffic_sim.py` : Trafik Ã¼reteci | Yol tipi, saat dilimi | SimÃ¼le araba hizlari |
 | `visualizer.py` : Folium harita | Rota node listesi | `.html` etkilesimli harita |
-| `test_scenarios.py` : E2E testler | A/B noktalari, CC, mod | Beklenen vs gerçek rota |
+| `test_scenarios.py` : E2E testler | A/B noktalari, CC, mod | Beklenen vs gerÃ§ek rota |
 
-#### Faz 5 — Üretime Hazirlik
+#### Faz 5 â€” Ãœretime Hazirlik
 
-| Görev | Açiklama |
+| GÃ¶rev | AÃ§iklama |
 |:---|:---|
 | REST API (`FastAPI`) | Mobil uygulamanin rota taleplerini alacak backend sunucu |
-| IBB API entegrasyonu | Gerçek zamanli trafik verisini simülasyon yerine baglama |
-| Mobil MVP (`Flutter`) | Kayit ekrani (CC girisi), mod seçimi, harita görünümü |
+| IBB API entegrasyonu | GerÃ§ek zamanli trafik verisini simÃ¼lasyon yerine baglama |
+| Mobil MVP (`Flutter`) | Kayit ekrani (CC girisi), mod seÃ§imi, harita gÃ¶rÃ¼nÃ¼mÃ¼ |
 
-### Modül Bagimliliklari
+### ModÃ¼l Bagimliliklari
 
 ```mermaid
 graph TD
@@ -549,39 +593,49 @@ graph TD
 ## Proje Durumu
 
 - [x] Algoritma tasarimi ve matematiksel modelleme
-- [x] README ve dokümantasyon
-- [ ] Proje dosya yapisi ve paketleme
-- [ ] OSM veri çekme ve graf olusturma
-- [ ] DEM entegrasyonu ve egim hesaplama
-- [ ] Veri temizleme (lanes, maxspeed, surface)
-- [ ] Lane filtering hiz fonksiyonu
-- [ ] CC bazli kisitlama sistemi
-- [ ] Egim ceza çarpani
-- [ ] Bilesik maliyet fonksiyonu
-- [ ] Dijkstra rota çözücü
-- [ ] Gezi modu: yüzey filtresi
-- [ ] Gezi modu: sinuosity indeksi
-- [ ] Akilli trafik simülasyonu
-- [ ] Folium görsellestirme
-- [ ] Uçtan uca test senaryolari
-- [ ] REST API sunucusu (FastAPI)
-- [ ] IBB API entegrasyonu
-- [ ] Mobil uygulama MVP (Flutter)
+- [x] README ve dokumantasyon
+- [x] OSM tabanli routing cekirdegi
+- [x] DEM / egim entegrasyonu
+- [x] Veri temizleme: lanes, maxspeed, surface, lanes_forward
+- [x] BPR tabanli hiz modeli
+- [x] Canli trafik destekli edge speed blending
+- [x] Baglama duyarli lane filtering
+- [x] CC bazli kisitlama sistemi
+- [x] Mod bazli rota maliyetleri
+- [x] Dijkstra tabanli rota cozucu
+- [x] Weather-aware route cost
+- [x] Release notes ve research note
+- [ ] Provider-specific trafik adapterlari
+- [ ] Trace-based calibration loop
+- [ ] Production API rollout
+- [ ] Mobil uygulama MVP
 
 ---
 
-## Algoritma Parametreleri Özet Tablosu
+## Algoritma Parametreleri Ã–zet Tablosu
 
 | Parametre | Sembol | Veri Kaynagi | Algoritmaya Etkisi |
 |:---|:---:|:---:|:---|
 | Motosiklet Hacmi | $CC$ | Kullanici | $\leq 50$: otoban $= \infty$, egim cezalari aktif |
-| Serit Sayisi | $n_{serit}$ | OSM `lanes` | Arttikça $V_{moto}$ yükselir |
+| Serit Sayisi | $n_{serit}$ | OSM `lanes` | ArttikÃ§a $V_{moto}$ yÃ¼kselir |
 | Yol Egimi | $\alpha$ | DEM `.tif` | $> 5\%$: maliyet $1.5\times - 10\times$ artar |
-| Yüzey Tipi | $surface$ | OSM `surface` | Gezi modunda istenmeyen $= 50\times$ ceza |
-| Sürüs Amaci | $mod$ | Kullanici | Is: $\min T$, Gezi: $\min (d \times C_y \times C_v)$ |
-| Anlik Trafik | $V_{araba}$ | IBB / Sim | Lane filtering tetikleyicisi |
+| YÃ¼zey Tipi | $surface$ | OSM `surface` | Free-flow speed ve gezi tercihlerini etkiler |
+| SÃ¼rÃ¼s Amaci | $mod$ | Kullanici | Is: $\min T$, Gezi: $\min (d \times C_y \times C_v)$ |
+| V/C Orani | $\frac{V}{C}$ | feed veya hacim/kapasite | BPR sikisiklik tepkisini belirler |
+| Canli Hiz | $V_{live}$ | trafik saglayicisi | BPR sonucuyla birlestirilir |
+| Guven Katsayisi | $\lambda$ | trafik saglayicisi | canli hizi ne kadar dinleyecegimizi belirler |
+| Hava Guvenligi | $S_e$ | weather assessment | edge hizi ve route cost'u dusurur |
+| Incident Siddeti | $I_e$ | trafik/olay feed'i | mod bazli cezayi artirir |
 | Hiz Siniri | $V_{max}$ | OSM `maxspeed` | Akici trafikte tavan hiz |
-| Tek Yön | $oneway$ | OSM `oneway` | $n_{serit}^{gidis}$ hesabi |
+| Tek YÃ¶n | $oneway$ | OSM `oneway` | $n_{serit}^{gidis}$ hesabi |
+
+---
+
+## Surum Notlari
+
+- Guncel release: `v0.6.0`
+- Bu surumde README, website release note ve GitHub release body canli trafik destekli routing modeline gore guncellendi.
+- Ana yenilikler: live traffic-aware routing, directional `V/C`, speed blending, weather ve incident-aware cost, context-aware lane filtering.
 
 ---
 
@@ -591,13 +645,13 @@ Bu proje [MIT License](LICENSE) altinda lisanslanmistir.
 
 ## Yazar
 
-**Ali Özuysal**
+**Ali Ã–zuysal**
 **Muhammet Yagcioglu**
 
 ---
 
 <div align="center">
 
-*MOTOMAP — Çünkü motosikletçilerin rotasi arabalara göre çizilemez.*
+*MOTOMAP â€” Ã‡Ã¼nkÃ¼ motosikletÃ§ilerin rotasi arabalara gÃ¶re Ã§izilemez.*
 
 </div>

--- a/docs/release-notes/v0.6.0.md
+++ b/docs/release-notes/v0.6.0.md
@@ -1,0 +1,57 @@
+# MotoMap v0.6.0
+
+**Date:** 2026-04-12
+
+MotoMap routing now supports live traffic speed and directional flow inputs, weather-aware route costs, context-aware lane filtering, and automatic cache invalidation for traffic updates.
+
+## Highlights
+
+- Added directional capacity logic and live volume ingestion:
+
+  $$
+  \left(\frac{V}{C}\right)_e = \frac{Q_e}{n_{fwd,e}\,c_{lane,e}}
+  $$
+
+- Added live-speed blending on top of BPR:
+
+  $$
+  V^{*}_{car,e} = (1-\lambda_e)\,V^{BPR}_{car,e} + \lambda_e\,V^{live}_{e}
+  $$
+
+- Reworked motorcycle lane filtering into a bounded low-speed maneuver:
+
+  $$
+  V_{moto,e} =
+  \min\!\left(
+  V^{*}_{car,e} + \Delta_{lane,e}\,m_{weather,e}\,m_{context,e},
+  \;V_{filter,max}
+  \right)
+  $$
+
+- Added weather and incident penalties directly to route cost:
+
+  $$
+  C_{mode,e} = T_e \cdot \left[1 + \omega_{mode}(1-S_e) + \phi_{mode} I_e\right]
+  $$
+
+## What changed in code
+
+- `motomap/algorithm.py`
+  - live `vc_ratio`, live volume, and provider speed categories now feed congestion
+  - live speed blending now updates edge speed estimates
+  - tunnel, night, heavy vehicle share, and narrow lane width now suppress filtering
+  - weather and incident penalties now affect `standart`, `viraj_keyfi`, and `guvenli`
+  - cache token now includes live traffic and weather context
+- `motomap/config.py`
+  - added live-traffic confidence, safe filtering envelope, and weather/incident weights
+- `tests/test_algorithm.py`
+  - added regression coverage for live speed and volume, tunnel suppression, weather penalties, and cache invalidation
+
+## Sources
+
+- Google Routes Preferred traffic intervals: https://developers.google.com/maps/documentation/routes_preferred/traffic_on_polylines
+- HERE Traffic API v7: https://docs.here.com/here-traffic-api
+- TomTom Vector Flow Tiles: https://developer.tomtom.com/traffic-api/documentation/tomtom-orbis-maps/traffic-flow/vector-flow-tiles
+- FHWA Dynamic Traffic Assignment guide: https://ops.fhwa.dot.gov/publications/fhwahop13015/sec6.htm
+- SUMO Simulation and SublaneModel: https://sumo.dlr.de/daily/userdoc/Simulation/
+- TRID: lane-filtering behavior at urban intersections: https://trid.trb.org/View/2015883

--- a/docs/releases.html
+++ b/docs/releases.html
@@ -318,12 +318,177 @@
     <p class="page-sub">Algorithm changes, formula derivations, and version history.</p>
   </div>
 
+  <!-- ======== v0.6.0 ======== -->
+  <article class="version reveal" id="v0.6.0">
+    <div class="version-header">
+      <span class="version-tag">v0.6.0</span>
+      <span class="version-date">2026-04-12</span>
+      <span class="badge badge-latest">Latest</span>
+    </div>
+
+    <p class="version-summary">
+      MotoMap routing now accepts <strong>live traffic speed</strong>,
+      <strong>directional traffic volume</strong>,
+      <strong>provider speed categories</strong>,
+      and <strong>weather / incident safety context</strong>.
+      The routing core blends observed speed with BPR, activates motorcycle
+      filtering only in realistic low-speed congestion, and automatically
+      invalidates cached travel times when live edge traffic changes.
+    </p>
+
+    <div class="cg cg-new">
+      <div class="cg-title"><i data-lucide="sparkles" class="cg-icon" style="color:var(--green)"></i> New Features</div>
+      <ul class="cl">
+        <li>
+          <strong>Directional Capacity from Live Flow</strong> &mdash; When
+          <code>traffic_volume_vph</code> is present, MotoMap now computes
+          edge-level congestion from forward lanes and practical per-lane capacity.
+          <div class="formula">
+            <div class="formula-label">Directional V/C Ratio</div>
+            $$ \left(\frac{V}{C}\right)_e = \frac{Q_e}{n_{fwd,e} \cdot c_{lane,e}} $$
+            <p class="formula-note">
+              This upgrades <code>ROAD_CAPACITY_PER_LANE</code> from a static
+              reference table into an active routing input.
+            </p>
+          </div>
+        </li>
+        <li>
+          <strong>Live Speed Blending</strong> &mdash; The BPR estimate is now
+          blended with provider speed feeds such as Google polyline traffic,
+          HERE flow speed, or TomTom flow tiles.
+          <div class="formula">
+            <div class="formula-label">Traffic-Aware Car Speed</div>
+            $$ V^{*}_{car,e} = (1-\lambda_e)\,V^{BPR}_{car,e} + \lambda_e\,V^{live}_{e} $$
+            <p class="formula-note">
+              $\lambda_e$ is the per-edge live traffic confidence. This keeps
+              the model stable under noisy feeds while remaining responsive.
+            </p>
+          </div>
+        </li>
+        <li>
+          <strong>Context-Aware Motorcycle Filtering</strong> &mdash; Lane
+          filtering is no longer treated as an unrestricted speed bonus. It is
+          now bounded by congestion state, weather, tunnel context, night mode,
+          heavy-vehicle share, and lane width.
+          <div class="formula">
+            <div class="formula-label">Bounded Filtering Envelope</div>
+            $$ V_{moto,e} =
+            \min\!\left(
+            V^{*}_{car,e} + \Delta_{lane,e}\,m_{weather,e}\,m_{context,e},
+            V_{filter,max}
+            \right) $$
+            <p class="formula-note">
+              Tunnels fully suppress filtering. Narrow lanes and heavy vehicles
+              reduce the benefit rather than removing it abruptly.
+            </p>
+          </div>
+        </li>
+        <li>
+          <strong>Weather-Aware Route Cost</strong> &mdash; Weather and incident
+          severity now affect route weights, not just UI analysis.
+          <div class="formula">
+            <div class="formula-label">Mode Cost with Safety and Incidents</div>
+            $$ C_{mode,e} = T_e \cdot \left[1 + \omega_{mode}(1-S_e) + \phi_{mode} I_e\right] $$
+            <p class="formula-note">
+              <code>guvenli</code> uses the strongest $\omega_{mode}$ and
+              $\phi_{mode}$, while <code>viraj_keyfi</code> stays lighter.
+            </p>
+          </div>
+        </li>
+        <li>
+          <strong>Graph-Wide Weather Projection Helper</strong> &mdash;
+          <code>apply_weather_assessment_to_graph()</code> now maps route-level
+          motorcycle weather assessments directly onto every edge before routing.
+        </li>
+      </ul>
+    </div>
+
+    <div class="cg cg-changed">
+      <div class="cg-title"><i data-lucide="refresh-cw" class="cg-icon" style="color:var(--orange)"></i> Changed</div>
+      <ul class="cl">
+        <li>
+          <strong><code>_effective_speed_kmh()</code></strong> now resolves
+          traffic state from <code>vc_ratio</code>, live directional flow,
+          provider speed categories (<code>NORMAL</code>, <code>SLOW</code>,
+          <code>TRAFFIC_JAM</code>), and live speed confidence.
+        </li>
+        <li>
+          <strong><code>RoutingAlgorithmProfile</code></strong> gained live-traffic
+          confidence defaults, a safe filtering envelope, and weather / incident
+          penalty weights for each riding mode.
+        </li>
+        <li>
+          <strong><code>RuntimeCalibration</code></strong> now supports
+          weather-safety and lane-splitting overrides via environment variables.
+        </li>
+        <li>
+          <strong><code>_graph_cache_token()</code></strong> now includes live
+          traffic, weather, and filtering context fields, so cache invalidation
+          is automatic when edge traffic changes.
+        </li>
+      </ul>
+    </div>
+
+    <div class="cg cg-fixed">
+      <div class="cg-title"><i data-lucide="wrench" class="cg-icon" style="color:var(--accent)"></i> Fixed</div>
+      <ul class="cl">
+        <li>
+          <strong>Traffic-ready but partially manual cache reset</strong> &mdash;
+          live traffic changes now invalidate cached travel times automatically.
+        </li>
+        <li>
+          <strong>Lane filtering in unrealistic contexts</strong> &mdash;
+          tunnel and unsafe low-clearance contexts no longer receive the same
+          filtering benefit as open mixed traffic.
+        </li>
+        <li>
+          <strong>Capacity table was defined but not active</strong> &mdash;
+          <code>ROAD_CAPACITY_PER_LANE</code> now participates in live
+          congestion estimation when volume is available.
+        </li>
+      </ul>
+    </div>
+
+    <div class="cg cg-refs">
+      <div class="cg-title"><i data-lucide="book-open" class="cg-icon" style="color:var(--purple)"></i> Research References</div>
+      <ul class="cl">
+        <li>
+          <strong>Google Routes Preferred</strong> &mdash;
+          <a href="https://developers.google.com/maps/documentation/routes_preferred/traffic_on_polylines" target="_blank" rel="noopener noreferrer">traffic speed reading intervals on polylines</a>.
+        </li>
+        <li>
+          <strong>HERE Traffic API v7</strong> &mdash;
+          <a href="https://docs.here.com/here-traffic-api" target="_blank" rel="noopener noreferrer">real-time flow, current speed, and jam information</a>.
+        </li>
+        <li>
+          <strong>TomTom Orbis Traffic Flow</strong> &mdash;
+          <a href="https://developer.tomtom.com/traffic-api/documentation/tomtom-orbis-maps/traffic-flow/vector-flow-tiles" target="_blank" rel="noopener noreferrer">current speed and free-flow delta per segment</a>.
+        </li>
+        <li>
+          <strong>FHWA DTA Guidebook</strong> &mdash;
+          <a href="https://ops.fhwa.dot.gov/publications/fhwahop13015/sec6.htm" target="_blank" rel="noopener noreferrer">network-sensitive dynamic traffic assignment guidance</a>.
+        </li>
+        <li>
+          <strong>SUMO Sublane / mixed traffic practice</strong> &mdash;
+          <a href="https://sumo.dlr.de/daily/userdoc/Simulation/" target="_blank" rel="noopener noreferrer">simulation support for lateral mixed-traffic behavior</a>.
+        </li>
+        <li>
+          <strong>Motorcycle lane filtering study</strong> &mdash;
+          <a href="https://trid.trb.org/View/2015883" target="_blank" rel="noopener noreferrer">Promraksa et al. (2022) on signalized urban intersections</a>.
+        </li>
+        <li>
+          <strong>MotoMap research note</strong> &mdash;
+          <a href="research/2026-04-12-live-traffic-motorcycle-routing.md">implementation rationale, formulas, and source map</a>.
+        </li>
+      </ul>
+    </div>
+  </article>
+
   <!-- ======== v0.5.0 ======== -->
   <article class="version reveal" id="v0.5.0">
     <div class="version-header">
       <span class="version-tag">v0.5.0</span>
       <span class="version-date">2026-04-11</span>
-      <span class="badge badge-latest">Latest</span>
       <span class="badge badge-breaking">Breaking</span>
     </div>
 

--- a/docs/research/2026-04-12-live-traffic-motorcycle-routing.md
+++ b/docs/research/2026-04-12-live-traffic-motorcycle-routing.md
@@ -1,0 +1,184 @@
+[![Language: English](https://img.shields.io/badge/Language-English-1f6feb)](2026-04-12-live-traffic-motorcycle-routing.md)
+
+# Live Traffic and Motorcycle Routing Research Note
+
+**Date:** 2026-04-12
+
+## 1. Executive summary
+
+Recent production routing systems and transport-engineering workflows do not rely on a single static speed factor. They usually combine:
+
+1. edge-level live traffic observations such as current speed, free-flow speed, jam level, or speed categories,
+2. directional capacity and volume logic for congestion,
+3. context-aware penalties for maneuvers that are only valid in low-speed mixed traffic,
+4. weather and incident safety modifiers,
+5. explicit cache or state invalidation whenever live traffic updates arrive.
+
+That is the pattern MotoMap now follows.
+
+## 2. What recent sources show
+
+### A. Live traffic feeds are edge- or segment-based, not only OD based
+
+- **Google Routes Preferred** exposes `speedReadingIntervals` with categories such as `NORMAL`, `SLOW`, and `TRAFFIC_JAM` along the returned polyline.
+- **HERE Traffic API v7** exposes real-time flow information including current speed and jam factor.
+- **TomTom Orbis Traffic Flow** exposes current speed and the difference from free-flow speed in vector flow tiles.
+
+Practical implication:
+
+- routing should accept per-edge live traffic signals directly,
+- not just a single global congestion multiplier.
+
+### B. Congestion should still be grounded in link performance logic
+
+FHWA guidance on dynamic traffic assignment emphasizes that dynamic traffic models are sensitive to detailed network inputs and need link-level state updates. Recent BPR research also focuses on improving the classical link function rather than abandoning link-level congestion models outright.
+
+Practical implication:
+
+- keep BPR-style link performance as the planning backbone,
+- but allow live observations to override or blend with the model when available.
+
+### C. Motorcycle filtering is a low-speed mixed-traffic maneuver
+
+Recent motorcycle literature and simulation practice do not treat filtering as an unrestricted speed bonus. It depends on congestion, clearance, lateral context, and surrounding vehicle state. SUMO's `SublaneModel` exists precisely because lateral mixed-traffic behavior needs separate treatment from ordinary lane-following. The 2022 study by Promraksa et al. on lane filtering at signalized urban intersections shows that instant speed, side condition, lateral vehicle condition, and vehicle type affect lateral clearance.
+
+Practical implication:
+
+- filtering should activate only in congested, low-speed conditions,
+- tunnels, heavy-vehicle presence, narrow lanes, and night conditions should suppress the benefit.
+
+### D. Weather matters twice: speed and risk
+
+For motorcycle routing, weather is not just a UI warning. It changes both expected progress and acceptable maneuver envelope. In practice, weather should:
+
+- reduce effective speed under unsafe conditions,
+- and increase route cost in safety-oriented modes.
+
+## 3. Implementation decisions for MotoMap
+
+### 3.1 Directional capacity from lane count
+
+MotoMap now uses directional practical capacity when live flow is available:
+
+$$
+\left(\frac{V}{C}\right)_e = \frac{Q_e}{n_{fwd,e} \cdot c_{lane,e}}
+$$
+
+where:
+
+- $Q_e$ = live directional volume for edge $e$,
+- $n_{fwd,e}$ = forward lane count,
+- $c_{lane,e}$ = per-lane practical capacity.
+
+This turns `ROAD_CAPACITY_PER_LANE` from a documentation constant into an active routing input.
+
+### 3.2 Blending model-based and observed live speed
+
+MotoMap keeps BPR as the structural model and blends live speed when available:
+
+$$
+V^{*}_{car,e} = (1-\lambda_e)\,V^{BPR}_{car,e} + \lambda_e\,V^{live}_{e}
+$$
+
+where $\lambda_e \in [0,1]$ is the live-traffic confidence.
+
+Why this matters:
+
+- pure BPR is stable but can lag real conditions,
+- pure live speed is reactive but noisy,
+- blending is a practical compromise used in real systems.
+
+### 3.3 Context-aware lane filtering
+
+MotoMap now treats filtering as a bounded congestion maneuver:
+
+$$
+V_{moto,e} =
+\min\!\left(
+V^{*}_{car,e} + \Delta_{lane,e}\,m_{weather,e}\,m_{context,e},
+\;V_{filter,max}
+\right)
+$$
+
+with the following constraints:
+
+- only active when congestion is present,
+- only active when forward lanes $\ge 2$,
+- tunnels suppress filtering,
+- night conditions reduce filtering benefit,
+- heavy-vehicle share reduces benefit,
+- narrow lane widths reduce benefit,
+- filtered speed is capped.
+
+### 3.4 Weather-aware route cost
+
+MotoMap now applies weather and incident penalties directly into route cost:
+
+$$
+C_{mode,e} = T_e \cdot \left[1 + \omega_{mode}(1-S_e) + \phi_{mode} I_e\right]
+$$
+
+where:
+
+- $T_e$ = edge travel time,
+- $S_e \in [0,1]$ = edge weather safety score,
+- $I_e$ = incident severity,
+- $\omega_{mode}$ and $\phi_{mode}$ depend on riding mode.
+
+This allows:
+
+- `standart` to stay pragmatic,
+- `viraj_keyfi` to stay fun-oriented but not blind to weather,
+- `guvenli` to penalize unsafe open-road segments much more aggressively.
+
+### 3.5 Automatic invalidation for live traffic changes
+
+MotoMap's cache token now includes live traffic and safety attributes such as:
+
+- `vc_ratio`,
+- live speed and live volume,
+- provider speed categories,
+- weather safety score,
+- lane-splitting modifier,
+- incident severity,
+- tunnel and lane-width context.
+
+So traffic changes now force travel-time recomputation automatically instead of requiring manual cache clearing.
+
+## 4. Engineering trade-offs
+
+This is still not a full microscopic simulator or city-scale DTA package. It remains a production-oriented route-cost model.
+
+It now sits in a stronger middle ground:
+
+- better than a static motorcycle-aware router,
+- much lighter than SUMO-scale microsimulation,
+- compatible with current traffic feeds from Google, HERE, or TomTom,
+- and much closer to real mixed-traffic motorcycle behavior.
+
+## 5. Practical next steps
+
+1. Add a provider adapter that map-matches Google/HERE/TomTom traffic segments onto OSM edges.
+2. Store `traffic_speed_kmh`, `traffic_volume_vph`, `traffic_confidence`, and optional `incident_severity` per edge.
+3. Push weather assessments to the graph before routing when the forecast is refreshed.
+4. Calibrate confidence and weather weights on real rider traces or pilot telemetry.
+5. If needed later, use SUMO `SublaneModel` as an offline calibration environment instead of trying to run microsimulation in the request path.
+
+## 6. Internet sources
+
+1. Google Maps Platform, "Request Traffic Information on the Polyline"  
+   https://developers.google.com/maps/documentation/routes_preferred/traffic_on_polylines
+2. HERE, "Traffic API v7"  
+   https://docs.here.com/here-traffic-api
+3. TomTom Developer Portal, "Vector Flow Tiles"  
+   https://developer.tomtom.com/traffic-api/documentation/tomtom-orbis-maps/traffic-flow/vector-flow-tiles
+4. FHWA, "Traffic Analysis Toolbox Volume XIV: Guidebook on the Utilization of Dynamic Traffic Assignment in Modeling"  
+   https://ops.fhwa.dot.gov/publications/fhwahop13015/sec6.htm
+5. SUMO Documentation, "Simulation" and `SublaneModel`  
+   https://sumo.dlr.de/daily/userdoc/Simulation/
+6. SafeTREC, "2024 Traffic Safety Facts: Motorcycle Safety"  
+   https://safetrec.berkeley.edu/2024-safetrec-traffic-safety-facts-motorcycle-safety
+7. TRID record for Promraksa et al. (2022), "Lane-filtering behavior of motorcycle riders at signalized urban intersections"  
+   https://trid.trb.org/View/2015883
+8. TRID record for Gore et al. (2023), "Modified Bureau of Public Roads Link Function"  
+   https://trid.trb.org/View/2083568

--- a/motomap/__init__.py
+++ b/motomap/__init__.py
@@ -5,6 +5,7 @@ from motomap.algorithm import (
     EXCLUDED_HIGHWAY_TYPES,
     RoutingAlgorithmProfile,
     add_travel_time_to_graph,
+    apply_weather_assessment_to_graph,
     filter_motorcycle_edges,
     ucret_opsiyonlu_rota_hesapla,
 )
@@ -39,6 +40,7 @@ __all__ = [
     "motomap_graf_olustur",
     "ucret_opsiyonlu_rota_hesapla",
     "add_travel_time_to_graph",
+    "apply_weather_assessment_to_graph",
     "add_curve_and_risk_metrics",
     "analyze_linestring_curvature",
     "filter_motorcycle_edges",

--- a/motomap/algorithm.py
+++ b/motomap/algorithm.py
@@ -17,14 +17,29 @@ from motomap.config import (
     DEFAULT_MAXSPEED,
     DEFAULT_SURFACE,
     FREE_FLOW_SPEED_FACTOR,
+    GUVENLI_INCIDENT_PENALTY_WEIGHT,
+    GUVENLI_WEATHER_PENALTY_WEIGHT,
     INTERSECTION_DELAY_S,
+    LANE_FILTER_HEAVY_VEHICLE_PENALTY,
     LANE_FILTER_MIN_SPEED_KMH,
+    LANE_FILTER_MAX_CAR_SPEED_KMH,
+    LANE_FILTER_MAX_EFFECTIVE_SPEED_KMH,
+    LANE_FILTER_NARROW_LANE_MODIFIER,
+    LANE_FILTER_NARROW_LANE_WIDTH_M,
+    LANE_FILTER_NIGHT_MODIFIER,
     LANE_FILTER_SPEED_BONUS,
+    LANE_FILTER_TUNNEL_MODIFIER,
     LANE_FILTER_VC_THRESHOLD,
+    LIVE_TRAFFIC_DEFAULT_CONFIDENCE,
     MOTORWAY_MIN_CC,
     PEAK_HOUR_VC_RATIO,
     ROAD_CAPACITY_PER_LANE,
+    STANDART_INCIDENT_PENALTY_WEIGHT,
+    STANDART_WEATHER_PENALTY_WEIGHT,
     SURFACE_SPEED_FACTOR,
+    VIRAJ_INCIDENT_PENALTY_WEIGHT,
+    VIRAJ_WEATHER_PENALTY_WEIGHT,
+    WEATHER_SPEED_FLOOR_FACTOR,
 )
 
 TRAVEL_TIME_ATTR = "travel_time_s"
@@ -121,6 +136,8 @@ class RuntimeCalibration:
     segment_delay_s: float
     ferry_boarding_delay_s: float
     vc_ratio_override: float | None = None
+    weather_safety_override: float | None = None
+    lane_splitting_modifier_override: float | None = None
 
 
 @dataclass(frozen=True)
@@ -186,6 +203,21 @@ class RoutingAlgorithmProfile:
     )
     lane_filter_vc_threshold: float = LANE_FILTER_VC_THRESHOLD
     lane_filter_min_speed_kmh: float = LANE_FILTER_MIN_SPEED_KMH
+    default_live_traffic_confidence: float = LIVE_TRAFFIC_DEFAULT_CONFIDENCE
+    lane_filter_max_car_speed_kmh: float = LANE_FILTER_MAX_CAR_SPEED_KMH
+    lane_filter_max_effective_speed_kmh: float = LANE_FILTER_MAX_EFFECTIVE_SPEED_KMH
+    lane_filter_tunnel_modifier: float = LANE_FILTER_TUNNEL_MODIFIER
+    lane_filter_night_modifier: float = LANE_FILTER_NIGHT_MODIFIER
+    lane_filter_heavy_vehicle_penalty: float = LANE_FILTER_HEAVY_VEHICLE_PENALTY
+    lane_filter_narrow_lane_width_m: float = LANE_FILTER_NARROW_LANE_WIDTH_M
+    lane_filter_narrow_lane_modifier: float = LANE_FILTER_NARROW_LANE_MODIFIER
+    weather_speed_floor_factor: float = WEATHER_SPEED_FLOOR_FACTOR
+    standart_weather_penalty_weight: float = STANDART_WEATHER_PENALTY_WEIGHT
+    viraj_weather_penalty_weight: float = VIRAJ_WEATHER_PENALTY_WEIGHT
+    guvenli_weather_penalty_weight: float = GUVENLI_WEATHER_PENALTY_WEIGHT
+    standart_incident_penalty_weight: float = STANDART_INCIDENT_PENALTY_WEIGHT
+    viraj_incident_penalty_weight: float = VIRAJ_INCIDENT_PENALTY_WEIGHT
+    guvenli_incident_penalty_weight: float = GUVENLI_INCIDENT_PENALTY_WEIGHT
     excluded_highway_types: frozenset[str] = field(
         default_factory=lambda: EXCLUDED_HIGHWAY_TYPES
     )
@@ -243,6 +275,12 @@ def safe_float(value, default: float = 0.0) -> float:
         return default
 
 
+def clamp(value: float, lower: float, upper: float) -> float:
+    """Clamp ``value`` into the inclusive ``[lower, upper]`` interval."""
+
+    return max(lower, min(upper, float(value)))
+
+
 def parse_int(value, default: int) -> int:
     """Convert loose OSM-style values to ``int`` with list-aware fallbacks."""
 
@@ -258,6 +296,20 @@ def parse_int(value, default: int) -> int:
     if isinstance(value, list) and value:
         return parse_int(value[0], default)
     return default
+
+
+def parse_bool(value) -> bool:
+    """Parse loose truthy values commonly found in OSM-style metadata."""
+
+    if isinstance(value, list):
+        return any(parse_bool(item) for item in value)
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return str(value).strip().lower() in {"yes", "true", "1", "y"}
 
 
 def normalize_tag(value) -> str | None:
@@ -412,6 +464,8 @@ def _graph_cache_token(
             k,
             _cache_value_token(data.get("length")),
             _cache_value_token(data.get("maxspeed")),
+            _cache_value_token(data.get("lanes")),
+            _cache_value_token(data.get("lanes_forward")),
             _cache_value_token(data.get("duration")),
             _cache_value_token(data.get("route")),
             _cache_value_token(data.get("ferry")),
@@ -419,6 +473,32 @@ def _graph_cache_token(
             _cache_value_token(data.get("grade")),
             _cache_value_token(data.get("toll")),
             _cache_value_token(data.get("surface")),
+            _cache_value_token(data.get("tunnel")),
+            _cache_value_token(data.get("vc_ratio")),
+            _cache_value_token(data.get("traffic_vc_ratio")),
+            _cache_value_token(data.get("traffic_volume_vph")),
+            _cache_value_token(data.get("traffic_flow_vph")),
+            _cache_value_token(data.get("volume_vph")),
+            _cache_value_token(data.get("traffic_speed_kmh")),
+            _cache_value_token(data.get("current_speed_kmh")),
+            _cache_value_token(data.get("live_speed_kmh")),
+            _cache_value_token(data.get("traffic_free_flow_kmh")),
+            _cache_value_token(data.get("free_flow_speed_kmh")),
+            _cache_value_token(data.get("traffic_confidence")),
+            _cache_value_token(data.get("speed_confidence")),
+            _cache_value_token(data.get("traffic_speed_category")),
+            _cache_value_token(data.get("speed_category")),
+            _cache_value_token(data.get("weather_overall_safety")),
+            _cache_value_token(data.get("lane_splitting_modifier")),
+            _cache_value_token(data.get("wind_risk_factor")),
+            _cache_value_token(data.get("incident_severity")),
+            _cache_value_token(data.get("traffic_incident")),
+            _cache_value_token(data.get("traffic_closed")),
+            _cache_value_token(data.get("is_night")),
+            _cache_value_token(data.get("lane_width_m")),
+            _cache_value_token(data.get("traffic_heavy_vehicle_share")),
+            _cache_value_token(data.get("heavy_vehicle_share")),
+            _cache_value_token(data.get("capacity_per_lane_vph")),
         ]
         if include_curve_inputs:
             edge_signature.extend(
@@ -501,15 +581,33 @@ def runtime_calibration_from_env(
         default=profile.default_ferry_boarding_delay_s,
     )
     vc_raw = os.getenv("MOTOMAP_VC_RATIO")
+    weather_raw = os.getenv("MOTOMAP_WEATHER_SAFETY")
+    lane_split_raw = os.getenv("MOTOMAP_LANE_SPLITTING_MODIFIER")
     vc_ratio_override: float | None = None
+    weather_safety_override: float | None = None
+    lane_splitting_modifier_override: float | None = None
     if vc_raw is not None:
-        vc_ratio_override = min(1.5, max(0.0, safe_float(vc_raw, default=0.0)))
+        vc_ratio_override = clamp(safe_float(vc_raw, default=0.0), 0.0, 2.0)
+    if weather_raw is not None:
+        weather_safety_override = clamp(
+            safe_float(weather_raw, default=1.0),
+            0.0,
+            1.0,
+        )
+    if lane_split_raw is not None:
+        lane_splitting_modifier_override = clamp(
+            safe_float(lane_split_raw, default=1.0),
+            0.0,
+            1.25,
+        )
 
     return RuntimeCalibration(
-        speed_factor=min(1.0, max(0.2, speed_factor)),
-        segment_delay_s=min(8.0, max(0.0, segment_delay_s)),
-        ferry_boarding_delay_s=min(1800.0, max(0.0, ferry_boarding_delay_s)),
+        speed_factor=clamp(speed_factor, 0.2, 1.0),
+        segment_delay_s=clamp(segment_delay_s, 0.0, 8.0),
+        ferry_boarding_delay_s=clamp(ferry_boarding_delay_s, 0.0, 1800.0),
         vc_ratio_override=vc_ratio_override,
+        weather_safety_override=weather_safety_override,
+        lane_splitting_modifier_override=lane_splitting_modifier_override,
     )
 
 
@@ -576,6 +674,245 @@ def filter_motorcycle_edges(
     return graph.edge_subgraph(keep).copy()
 
 
+def _first_present_float(
+    edge_data: Mapping[str, object],
+    *keys: str,
+) -> float | None:
+    """Return the first positive float found among ``keys``."""
+
+    for key in keys:
+        if key not in edge_data:
+            continue
+        value = safe_float(edge_data.get(key), default=0.0)
+        if value > 0.0:
+            return value
+    return None
+
+
+def _forward_capacity_vph(
+    edge_data: Mapping[str, object],
+    profile: RoutingAlgorithmProfile,
+) -> float:
+    """Estimate practical directional capacity for the edge."""
+
+    highway = get_highway_type(edge_data)
+    lanes_forward = max(1, parse_int(edge_data.get("lanes_forward"), 1))
+    capacity_per_lane = _first_present_float(
+        edge_data,
+        "capacity_per_lane_vph",
+        "traffic_capacity_per_lane_vph",
+    )
+    if capacity_per_lane is None:
+        capacity_per_lane = safe_float(
+            profile.road_capacity_per_lane.get(highway, 600),
+            default=600.0,
+        )
+    return max(100.0, capacity_per_lane * lanes_forward)
+
+
+def _speed_category(edge_data: Mapping[str, object]) -> str | None:
+    """Normalize provider speed-category tags such as ``SLOW`` or ``TRAFFIC_JAM``."""
+
+    for key in ("traffic_speed_category", "speed_category"):
+        value = edge_data.get(key)
+        if value is None:
+            continue
+        category = str(value).strip().upper()
+        if category:
+            return category
+    return None
+
+
+def _live_speed_confidence(
+    edge_data: Mapping[str, object],
+    profile: RoutingAlgorithmProfile,
+) -> float:
+    """Resolve provider confidence for live speed data."""
+
+    explicit = _first_present_float(edge_data, "traffic_confidence", "speed_confidence")
+    if explicit is not None:
+        return clamp(explicit, 0.0, 1.0)
+    if _first_present_float(edge_data, "traffic_speed_kmh", "current_speed_kmh", "live_speed_kmh"):
+        return profile.default_live_traffic_confidence
+    return 0.0
+
+
+def _resolve_vc_ratio(
+    edge_data: Mapping[str, object],
+    calibration: RuntimeCalibration,
+    profile: RoutingAlgorithmProfile,
+) -> float:
+    """Resolve the link V/C ratio from override, live data, or planning defaults."""
+
+    highway = get_highway_type(edge_data)
+    if calibration.vc_ratio_override is not None:
+        return clamp(calibration.vc_ratio_override, 0.0, 2.0)
+
+    direct_vc = _first_present_float(edge_data, "vc_ratio", "traffic_vc_ratio")
+    if direct_vc is not None:
+        return clamp(direct_vc, 0.0, 2.0)
+
+    live_volume_vph = _first_present_float(
+        edge_data,
+        "traffic_volume_vph",
+        "traffic_flow_vph",
+        "volume_vph",
+    )
+    if live_volume_vph is not None:
+        return clamp(live_volume_vph / _forward_capacity_vph(edge_data, profile), 0.0, 2.0)
+
+    category = _speed_category(edge_data)
+    if category == "TRAFFIC_JAM":
+        return 1.10
+    if category == "SLOW":
+        return 0.85
+    if category == "NORMAL":
+        return 0.55
+
+    return clamp(profile.peak_hour_vc_ratio.get(highway, 0.0), 0.0, 2.0)
+
+
+def _resolve_weather_safety_score(
+    edge_data: Mapping[str, object],
+    calibration: RuntimeCalibration,
+) -> float:
+    """Resolve edge safety score from runtime override or edge metadata."""
+
+    if calibration.weather_safety_override is not None:
+        return clamp(calibration.weather_safety_override, 0.0, 1.0)
+    value = _first_present_float(
+        edge_data,
+        "weather_overall_safety",
+        "overall_safety_score",
+    )
+    if value is None:
+        return 1.0
+    return clamp(value, 0.0, 1.0)
+
+
+def _resolve_lane_splitting_modifier(
+    edge_data: Mapping[str, object],
+    calibration: RuntimeCalibration,
+    profile: RoutingAlgorithmProfile,
+) -> float:
+    """Resolve context-sensitive lane-filtering multiplier for the edge."""
+
+    if calibration.lane_splitting_modifier_override is not None:
+        modifier = calibration.lane_splitting_modifier_override
+    else:
+        explicit = _first_present_float(
+            edge_data,
+            "lane_splitting_modifier",
+            "weather_lane_splitting_modifier",
+        )
+        if explicit is not None:
+            modifier = explicit
+        else:
+            safety = _resolve_weather_safety_score(edge_data, calibration)
+            modifier = 0.65 + (0.35 * safety)
+
+    if normalize_tag(edge_data.get("tunnel")) == "yes":
+        modifier *= profile.lane_filter_tunnel_modifier
+    if parse_bool(edge_data.get("is_night")):
+        modifier *= profile.lane_filter_night_modifier
+
+    heavy_vehicle_share = _first_present_float(
+        edge_data,
+        "traffic_heavy_vehicle_share",
+        "heavy_vehicle_share",
+    )
+    if heavy_vehicle_share is not None:
+        modifier *= max(
+            0.35,
+            1.0 - (profile.lane_filter_heavy_vehicle_penalty * clamp(heavy_vehicle_share, 0.0, 1.0)),
+        )
+
+    lane_width_m = _first_present_float(edge_data, "lane_width_m")
+    if (
+        lane_width_m is not None
+        and 0.0 < lane_width_m < profile.lane_filter_narrow_lane_width_m
+    ):
+        modifier *= profile.lane_filter_narrow_lane_modifier
+
+    return clamp(modifier, 0.0, 1.25)
+
+
+def _mode_weather_penalty(
+    edge_data: Mapping[str, object],
+    surus_modu: str,
+    profile: RoutingAlgorithmProfile,
+) -> float:
+    """Return multiplicative weather and incident penalty for route cost."""
+
+    safety = clamp(
+        safe_float(edge_data.get("weather_overall_safety"), default=1.0),
+        0.0,
+        1.0,
+    )
+    incident_severity = clamp(
+        safe_float(edge_data.get("incident_severity"), default=0.0),
+        0.0,
+        1.5,
+    )
+    if parse_bool(edge_data.get("traffic_incident")):
+        incident_severity = max(incident_severity, 0.5)
+    if parse_bool(edge_data.get("traffic_closed")):
+        return 1e6
+
+    if surus_modu == "standart":
+        weather_weight = profile.standart_weather_penalty_weight
+        incident_weight = profile.standart_incident_penalty_weight
+    elif surus_modu == "viraj_keyfi":
+        weather_weight = profile.viraj_weather_penalty_weight
+        incident_weight = profile.viraj_incident_penalty_weight
+    else:
+        weather_weight = profile.guvenli_weather_penalty_weight
+        incident_weight = profile.guvenli_incident_penalty_weight
+
+    return 1.0 + (weather_weight * (1.0 - safety)) + (incident_weight * incident_severity)
+
+
+def apply_weather_assessment_to_graph(
+    graph: nx.MultiDiGraph,
+    weather_assessment,
+) -> nx.MultiDiGraph:
+    """Project a route-level weather assessment onto every edge in the graph."""
+
+    overall_safety = clamp(
+        safe_float(getattr(weather_assessment, "overall_safety_score", 1.0), default=1.0),
+        0.0,
+        1.0,
+    )
+    lane_modifier = clamp(
+        safe_float(getattr(weather_assessment, "lane_splitting_modifier", 1.0), default=1.0),
+        0.0,
+        1.0,
+    )
+    wind_risk = clamp(
+        safe_float(getattr(weather_assessment, "wind_risk_factor", 1.0), default=1.0),
+        0.0,
+        1.0,
+    )
+
+    for _, _, _, data in graph.edges(keys=True, data=True):
+        highway = get_highway_type(data)
+        tunnel = normalize_tag(data.get("tunnel")) == "yes"
+        edge_safety = overall_safety
+        edge_lane_modifier = lane_modifier
+
+        if tunnel:
+            edge_safety = max(edge_safety, 0.8)
+            edge_lane_modifier = 0.0
+        elif highway in {"motorway", "motorway_link", "trunk", "trunk_link"} and wind_risk < 0.7:
+            edge_safety *= 0.9
+
+        data["weather_overall_safety"] = clamp(edge_safety, 0.0, 1.0)
+        data["lane_splitting_modifier"] = clamp(edge_lane_modifier, 0.0, 1.0)
+        data["wind_risk_factor"] = wind_risk
+
+    return graph
+
+
 def _effective_speed_kmh(
     edge_data: Mapping[str, object],
     calibration: RuntimeCalibration,
@@ -584,7 +921,7 @@ def _effective_speed_kmh(
     """Compute effective motorcycle speed considering road class, surface,
     grade, traffic congestion (BPR model) and motorcycle lane filtering.
 
-    The model has five layers:
+    The model has six layers:
 
     Layer 1 -- Free-flow speed (HCM Ch. 23 methodology):
       V_ff = V_posted * f_class * f_surface * f_grade * f_global
@@ -593,21 +930,29 @@ def _effective_speed_kmh(
       f_bpr = 1 / [1 + alpha * (V/C) ^ beta]
       V_car = V_ff * f_bpr
 
-    Layer 3 -- Motorcycle lane-filtering advantage:
-      If V/C > threshold and lanes >= 2:
-        V_moto = V_car + bonus(lanes)
+    Layer 3 -- Live traffic blending:
+      V_car^* = (1 - lambda) * V_car + lambda * V_live
+
+    Layer 4 -- Motorcycle lane-filtering advantage:
+      If congestion is active and lanes >= 2:
+        V_moto = V_car^* + bonus(lanes, weather, context)
       Else:
-        V_moto = V_car
+        V_moto = V_car^*
 
-    The V/C ratio can come from three sources (priority order):
+    Layer 5 -- Weather moderation:
+      V_weather = V_moto * f_weather
+
+    The V/C ratio can come from multiple sources (priority order):
       1. MOTOMAP_VC_RATIO env var (global override for testing)
-      2. edge_data["vc_ratio"] (per-edge live traffic feed)
-      3. profile.peak_hour_vc_ratio[highway] (statistical default)
+      2. edge_data["vc_ratio"] or edge_data["traffic_vc_ratio"]
+      3. edge_data["traffic_volume_vph"] / directional_capacity
+      4. provider speed categories such as NORMAL / SLOW / TRAFFIC_JAM
+      5. profile.peak_hour_vc_ratio[highway] (statistical default)
 
-    When MOTOMAP_VC_RATIO is unset and no per-edge data exists, the model
-    falls back to peak-hour statistical V/C ratios, making it a planning-level
-    estimator.  When a real-time traffic feed populates edge_data["vc_ratio"],
-    the model becomes dynamically responsive to current conditions.
+    Live traffic feeds may also provide edge-level current speed, free-flow
+    speed, and confidence. Those values are blended with the BPR estimate to
+    avoid overreacting to noisy observations while remaining responsive to
+    current conditions.
     """
 
     highway = get_highway_type(edge_data)
@@ -626,30 +971,72 @@ def _effective_speed_kmh(
     v_ff = speed_kmh * f_class * f_surface * f_grade * calibration.speed_factor
 
     # Layer 2: BPR congestion
-    if calibration.vc_ratio_override is not None:
-        vc = calibration.vc_ratio_override
-    else:
-        edge_vc = edge_data.get("vc_ratio")
-        if edge_vc is not None:
-            vc = safe_float(edge_vc, default=0.0)
-        else:
-            vc = profile.peak_hour_vc_ratio.get(highway, 0.0)
-
+    vc = _resolve_vc_ratio(edge_data, calibration, profile)
     alpha = profile.bpr_alpha.get(highway, 0.15)
     beta = profile.bpr_beta.get(highway, 4.0)
     bpr_factor = 1.0 / (1.0 + alpha * (vc ** beta)) if vc > 0.0 else 1.0
-    v_car = v_ff * bpr_factor
+    v_car_model = v_ff * bpr_factor
 
-    # Layer 3: motorcycle lane-filtering advantage
+    # Layer 3: blend in live speed observations when present.
+    live_speed_kmh = _first_present_float(
+        edge_data,
+        "traffic_speed_kmh",
+        "current_speed_kmh",
+        "live_speed_kmh",
+    )
+    if live_speed_kmh is not None:
+        live_speed_cap = _first_present_float(
+            edge_data,
+            "traffic_free_flow_kmh",
+            "free_flow_speed_kmh",
+        )
+        if live_speed_cap is None:
+            live_speed_cap = v_ff
+        live_speed_kmh = clamp(live_speed_kmh, 5.0, max(5.0, live_speed_cap))
+        live_confidence = _live_speed_confidence(edge_data, profile)
+        v_car = ((1.0 - live_confidence) * v_car_model) + (live_confidence * live_speed_kmh)
+    else:
+        v_car = v_car_model
+
+    # Layer 4: motorcycle lane-filtering advantage
     lanes_forward = parse_int(edge_data.get("lanes_forward"), 1)
-    if vc > profile.lane_filter_vc_threshold and lanes_forward >= 2:
+    speed_category = _speed_category(edge_data)
+    congestion_active = (
+        vc > profile.lane_filter_vc_threshold
+        or speed_category in {"SLOW", "TRAFFIC_JAM"}
+        or (live_speed_kmh is not None and v_car <= profile.lane_filter_max_car_speed_kmh)
+    )
+    if congestion_active and lanes_forward >= 2:
         bonus_key = min(lanes_forward, 3)
-        bonus = profile.lane_filter_speed_bonus.get(bonus_key, 5.0)
-        v_moto = max(v_car + bonus, profile.lane_filter_min_speed_kmh)
+        base_bonus = profile.lane_filter_speed_bonus.get(bonus_key, 5.0)
+        lane_modifier = _resolve_lane_splitting_modifier(edge_data, calibration, profile)
+        speed_window_factor = clamp(
+            (profile.lane_filter_max_car_speed_kmh - v_car)
+            / max(5.0, profile.lane_filter_max_car_speed_kmh - 5.0),
+            0.0,
+            1.0,
+        )
+        bonus = base_bonus * lane_modifier * speed_window_factor
+        if bonus > 0.0:
+            min_filtered_speed = profile.lane_filter_min_speed_kmh * max(0.5, lane_modifier)
+            v_moto = max(v_car + bonus, min_filtered_speed)
+            v_moto = min(
+                v_moto,
+                max(v_car, profile.lane_filter_max_effective_speed_kmh),
+            )
+        else:
+            v_moto = v_car
     else:
         v_moto = v_car
 
-    return max(5.0, v_moto)
+    # Layer 5: weather moderation. Unsafe conditions reduce effective speed,
+    # but the factor is bounded to avoid exploding ETA in globally bad weather.
+    weather_safety = _resolve_weather_safety_score(edge_data, calibration)
+    weather_factor = profile.weather_speed_floor_factor + (
+        (1.0 - profile.weather_speed_floor_factor) * weather_safety
+    )
+
+    return max(5.0, v_moto * weather_factor)
 
 
 def _intersection_delay(
@@ -674,18 +1061,22 @@ def compute_edge_travel_time(
 ) -> float:
     """Estimate edge travel time in seconds for roads and ferry segments.
 
-    The travel time model follows a three-layer approach adapted from HCM
+    The travel time model follows a layered approach adapted from HCM
     (Highway Capacity Manual) methodology:
 
     1. **Free-flow speed** is derived from the posted speed limit adjusted by
        road-class, surface-type and grade reduction factors.
-    2. **Segment traversal time** is length / effective_speed.
-    3. **Intersection delay** is added per-edge based on road class (proxy for
+    2. **Traffic state** is resolved from V/C, live speed, live volume, or
+       provider speed categories.
+    3. **Motorcycle filtering and weather moderation** modify the car-based
+       speed estimate in congested mixed traffic.
+    4. **Segment traversal time** is length / effective_speed.
+    5. **Intersection delay** is added per-edge based on road class (proxy for
        signal/stop density).
 
-    Without real-time traffic volume data the model cannot apply the full BPR
-    volume-delay function.  The ``speed_factor`` runtime knob serves as a
-    residual congestion proxy that can be tuned per deployment context.
+    When no live traffic exists the model falls back to statistical peak-hour
+    V/C defaults.  When live speed, volume, or provider traffic categories are
+    present, the edge time automatically shifts into a dynamic mode.
     """
 
     calibration = calibration or runtime_calibration_from_env(profile)
@@ -752,6 +1143,9 @@ def ensure_travel_time_to_graph(
         calibration.speed_factor,
         calibration.segment_delay_s,
         calibration.ferry_boarding_delay_s,
+        calibration.vc_ratio_override,
+        calibration.weather_safety_override,
+        calibration.lane_splitting_modifier_override,
         graph_token,
     )
     if graph.graph.get("_motomap_travel_time_state") == state:
@@ -892,7 +1286,11 @@ def build_mode_specific_cost(
                 and (u in major_adjacent_nodes or v in major_adjacent_nodes)
             ):
                 road_penalty += profile.motorway_side_connector_penalty
-            data[weight_attr] = base * (1.0 + road_penalty)
+            data[weight_attr] = base * (1.0 + road_penalty) * _mode_weather_penalty(
+                data,
+                "standart",
+                profile,
+            )
         graph.graph["_motomap_route_revision"] = (
             int(graph.graph.get("_motomap_route_revision", 0)) + 1
         )
@@ -932,7 +1330,11 @@ def build_mode_specific_cost(
             road_bonus = profile.viraj_keyfi_road_bonus.get(highway, 0.0)
             bonus = 1.0 + 0.95 * curvature_term + 0.70 * fun_density_term + road_bonus
             penalty = 1.0 + 0.25 * danger_density_term + 0.45 * high_risk
-            data[weight_attr] = (base / max(1e-6, bonus)) * penalty
+            data[weight_attr] = (
+                (base / max(1e-6, bonus))
+                * penalty
+                * _mode_weather_penalty(data, "viraj_keyfi", profile)
+            )
             continue
 
         road_penalty = profile.guvenli_road_penalty.get(highway, 0.0)
@@ -944,7 +1346,11 @@ def build_mode_specific_cost(
             + 5.00 * downhill_penalty
             + road_penalty
         )
-        data[weight_attr] = base * penalty
+        data[weight_attr] = (
+            base
+            * penalty
+            * _mode_weather_penalty(data, "guvenli", profile)
+        )
 
     graph.graph["_motomap_route_revision"] = (
         int(graph.graph.get("_motomap_route_revision", 0)) + 1

--- a/motomap/config.py
+++ b/motomap/config.py
@@ -224,3 +224,24 @@ LANE_FILTER_SPEED_BONUS: dict[int, float] = {
 }
 LANE_FILTER_VC_THRESHOLD = 0.60  # V/C above which lane filtering activates
 LANE_FILTER_MIN_SPEED_KMH = 15.0  # minimum motorcycle speed even in gridlock
+
+# Practical lane-filtering envelope used by the real-time model.  Recent
+# mixed-traffic and safety literature supports treating lane filtering as a
+# low-speed congestion maneuver rather than a general cruising-speed bonus.
+LIVE_TRAFFIC_DEFAULT_CONFIDENCE = 0.65
+LANE_FILTER_MAX_CAR_SPEED_KMH = 40.0
+LANE_FILTER_MAX_EFFECTIVE_SPEED_KMH = 42.0
+LANE_FILTER_TUNNEL_MODIFIER = 0.0
+LANE_FILTER_NIGHT_MODIFIER = 0.75
+LANE_FILTER_HEAVY_VEHICLE_PENALTY = 0.45
+LANE_FILTER_NARROW_LANE_WIDTH_M = 3.15
+LANE_FILTER_NARROW_LANE_MODIFIER = 0.72
+
+# Weather and incident penalties used by mode-specific routing costs.
+WEATHER_SPEED_FLOOR_FACTOR = 0.70
+STANDART_WEATHER_PENALTY_WEIGHT = 0.30
+VIRAJ_WEATHER_PENALTY_WEIGHT = 0.20
+GUVENLI_WEATHER_PENALTY_WEIGHT = 0.75
+STANDART_INCIDENT_PENALTY_WEIGHT = 0.35
+VIRAJ_INCIDENT_PENALTY_WEIGHT = 0.20
+GUVENLI_INCIDENT_PENALTY_WEIGHT = 0.85

--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -6,9 +6,11 @@ import pytest
 from motomap.algorithm import (
     FERRY_CUSTOM_FILTER,
     TRAVEL_TIME_ATTR,
+    apply_weather_assessment_to_graph,
     build_mode_specific_cost,
     build_route_search_index,
     compute_edge_travel_time,
+    ensure_travel_time_to_graph,
     fill_edge_defaults,
     mode_weight_attr,
     runtime_calibration_from_env,
@@ -16,6 +18,7 @@ from motomap.algorithm import (
     summarize_route,
     ucret_opsiyonlu_rota_hesapla,
 )
+from motomap.weather.models import RoadConditionAssessment, RoadSurfaceCondition
 
 HIGHWAY_TYPES = (
     "primary",
@@ -273,3 +276,92 @@ def test_randomized_shortest_path_matches_networkx(case_id):
         assert summary["toplam_maliyet_s"] == pytest.approx(actual_cost)
         if not allow_toll:
             assert summary["ucretli_yol_iceriyor"] is False
+
+
+def test_compute_edge_travel_time_blends_live_volume_and_speed_feed():
+    baseline_edge = {
+        "highway": "primary",
+        "length": 1_000.0,
+        "maxspeed": 80,
+        "lanes": 4,
+        "lanes_forward": 2,
+    }
+    live_edge = {
+        **baseline_edge,
+        "traffic_volume_vph": 1_800.0,
+        "traffic_speed_kmh": 18.0,
+        "traffic_confidence": 1.0,
+    }
+
+    baseline = compute_edge_travel_time(baseline_edge)
+    live = compute_edge_travel_time(live_edge)
+
+    assert live > baseline
+
+
+def test_tunnel_edges_suppress_lane_filtering_bonus():
+    open_edge = {
+        "highway": "primary",
+        "length": 1_000.0,
+        "maxspeed": 80,
+        "lanes": 4,
+        "lanes_forward": 2,
+        "vc_ratio": 1.0,
+        "traffic_speed_kmh": 10.0,
+        "traffic_confidence": 1.0,
+    }
+    tunnel_edge = {**open_edge, "tunnel": "yes"}
+
+    open_time = compute_edge_travel_time(open_edge)
+    tunnel_time = compute_edge_travel_time(tunnel_edge)
+
+    assert tunnel_time > open_time
+
+
+def test_apply_weather_assessment_to_graph_penalizes_open_highways():
+    graph = nx.MultiDiGraph()
+    graph.add_edge(1, 2, 0, highway="motorway", travel_time_s=100.0, length=1000.0)
+    graph.add_edge(1, 3, 0, highway="secondary", travel_time_s=100.0, length=1000.0)
+
+    assessment = RoadConditionAssessment(
+        surface_condition=RoadSurfaceCondition.WET,
+        grip_factor=0.7,
+        visibility_factor=0.9,
+        wind_risk_factor=0.4,
+        overall_safety_score=0.55,
+        lane_splitting_modifier=0.45,
+        warnings=["wind"],
+    )
+    apply_weather_assessment_to_graph(graph, assessment)
+    weight_attr = build_mode_specific_cost(
+        graph,
+        surus_modu="standart",
+        base_weight=TRAVEL_TIME_ATTR,
+    )
+
+    assert graph.edges[1, 2, 0]["weather_overall_safety"] < graph.edges[1, 3, 0]["weather_overall_safety"]
+    assert graph.edges[1, 2, 0][weight_attr] > graph.edges[1, 3, 0][weight_attr]
+
+
+def test_live_traffic_changes_invalidate_cached_travel_time():
+    graph = nx.MultiDiGraph()
+    graph.add_edge(
+        1,
+        2,
+        0,
+        highway="primary",
+        length=1_000.0,
+        maxspeed=80,
+        lanes=4,
+        lanes_forward=2,
+    )
+
+    ensure_travel_time_to_graph(graph)
+    baseline = graph.edges[1, 2, 0][TRAVEL_TIME_ATTR]
+
+    graph.edges[1, 2, 0]["traffic_speed_kmh"] = 12.0
+    graph.edges[1, 2, 0]["traffic_confidence"] = 1.0
+    ensure_travel_time_to_graph(graph)
+    updated = graph.edges[1, 2, 0][TRAVEL_TIME_ATTR]
+
+    assert updated > baseline


### PR DESCRIPTION
# MotoMap v0.6.0

**Date:** 2026-04-12

MotoMap routing now supports live traffic speed and directional flow inputs, weather-aware route costs, context-aware lane filtering, and automatic cache invalidation for traffic updates.

## Highlights

- Added directional capacity logic and live volume ingestion:

  $$
  \left(\frac{V}{C}\right)_e = \frac{Q_e}{n_{fwd,e}\,c_{lane,e}}
  $$

- Added live-speed blending on top of BPR:

  $$
  V^{*}_{car,e} = (1-\lambda_e)\,V^{BPR}_{car,e} + \lambda_e\,V^{live}_{e}
  $$

- Reworked motorcycle lane filtering into a bounded low-speed maneuver:

  $$
  V_{moto,e} =
  \min\!\left(
  V^{*}_{car,e} + \Delta_{lane,e}\,m_{weather,e}\,m_{context,e},
  \;V_{filter,max}
  \right)
  $$

- Added weather and incident penalties directly to route cost:

  $$
  C_{mode,e} = T_e \cdot \left[1 + \omega_{mode}(1-S_e) + \phi_{mode} I_e\right]
  $$

## What changed in code

- `motomap/algorithm.py`
  - live `vc_ratio`, live volume, and provider speed categories now feed congestion
  - live speed blending now updates edge speed estimates
  - tunnel, night, heavy vehicle share, and narrow lane width now suppress filtering
  - weather and incident penalties now affect `standart`, `viraj_keyfi`, and `guvenli`
  - cache token now includes live traffic and weather context
- `motomap/config.py`
  - added live-traffic confidence, safe filtering envelope, and weather/incident weights
- `tests/test_algorithm.py`
  - added regression coverage for live speed and volume, tunnel suppression, weather penalties, and cache invalidation

## Sources

- Google Routes Preferred traffic intervals: https://developers.google.com/maps/documentation/routes_preferred/traffic_on_polylines
- HERE Traffic API v7: https://docs.here.com/here-traffic-api
- TomTom Vector Flow Tiles: https://developer.tomtom.com/traffic-api/documentation/tomtom-orbis-maps/traffic-flow/vector-flow-tiles
- FHWA Dynamic Traffic Assignment guide: https://ops.fhwa.dot.gov/publications/fhwahop13015/sec6.htm
- SUMO Simulation and SublaneModel: https://sumo.dlr.de/daily/userdoc/Simulation/
- TRID: lane-filtering behavior at urban intersections: https://trid.trb.org/View/2015883
